### PR TITLE
Initial implementation of new validation approach

### DIFF
--- a/src/Promitor.Core.Scraping/Configuration/Serialization/ConfigurationSerializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/ConfigurationSerializer.cs
@@ -57,7 +57,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
             switch (specVersion)
             {
                 case SpecVersion.v1:
-                    var v1Config = _v1Deserializer.Deserialize(rootNode);
+                    var errorReporter = new ErrorReporter();
+                    var v1Config = _v1Deserializer.Deserialize(rootNode, errorReporter);
 
                     return _mapper.Map<MetricsDeclaration>(v1Config);
                 default:

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/Deserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/Deserializer.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
 using System.Runtime.Serialization;
 using GuardNet;
 using Microsoft.Extensions.Logging;
@@ -7,7 +11,10 @@ using YamlDotNet.RepresentationModel;
 namespace Promitor.Core.Scraping.Configuration.Serialization
 {
     public abstract class Deserializer<TObject> : IDeserializer<TObject>
+        where TObject: new()
     {
+        private readonly Dictionary<string, FieldContext> _fields = new Dictionary<string, FieldContext>();
+
         protected ILogger Logger { get; }
 
         protected Deserializer(ILogger logger)
@@ -17,9 +24,41 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
             Logger = logger;
         }
 
-        public abstract TObject Deserialize(YamlMappingNode node);
+        /// <inheritdoc />
+        public virtual TObject Deserialize(YamlMappingNode node, IErrorReporter errorReporter)
+        {
+            var result = new TObject();
 
-        public List<TObject> Deserialize(YamlSequenceNode nodes)
+            foreach (var child in node.Children)
+            {
+                if (_fields.TryGetValue(child.Key.ToString(), out var fieldContext))
+                {
+                    fieldContext.SetValue(
+                        result, GetFieldValue(child, fieldContext, errorReporter));
+                }
+                else
+                {
+                    errorReporter.ReportWarning(child.Key, $"Unknown field '{child.Key}'.");
+                }
+            }
+
+            foreach (var unsetField in _fields.Where(field => !field.Value.HasBeenSet))
+            {
+                if (unsetField.Value.IsRequired)
+                {
+                    errorReporter.ReportError(node, $"'{unsetField.Key}' is a required field but was not found.");
+                }
+                else
+                {
+                    unsetField.Value.SetDefaultValue(result);
+                }
+            }
+
+            return result;
+        }
+
+        /// <inheritdoc />
+        public List<TObject> Deserialize(YamlSequenceNode nodes, IErrorReporter errorReporter)
         {
             Guard.NotNull(nodes, nameof(nodes));
 
@@ -31,11 +70,106 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
                     throw new SerializationException($"Failed parsing metrics because we couldn't cast an item to {nameof(YamlMappingNode)}");
                 }
 
-                var deserializedObject = Deserialize(metricNode);
+                var deserializedObject = Deserialize(metricNode, errorReporter);
                 deserializedObjects.Add(deserializedObject);
             }
 
             return deserializedObjects;
+        }
+
+        protected void MapRequired<TReturn>(Expression<Func<TObject, TReturn>> accessorExpression, Func<string, KeyValuePair<YamlNode, YamlNode>, IErrorReporter, object> customMapperFunc = null)
+        {
+            var memberExpression = (MemberExpression)accessorExpression.Body;
+            _fields[GetName(memberExpression)] = new FieldContext(memberExpression.Member as PropertyInfo, true, default(TReturn), customMapperFunc);
+        }
+        
+        protected void MapOptional<TReturn>(Expression<Func<TObject, TReturn>> accessorExpression, TReturn defaultValue = default, Func<string, KeyValuePair<YamlNode, YamlNode>, IErrorReporter, object> customMapperFunc = null)
+        {
+            var memberExpression = (MemberExpression)accessorExpression.Body;
+            _fields[GetName(memberExpression)] = new FieldContext(memberExpression.Member as PropertyInfo, false, defaultValue, customMapperFunc);
+        }
+
+        private static string GetName(MemberExpression memberExpression)
+        {
+            return Char.ToLowerInvariant(memberExpression.Member.Name[0]) + memberExpression.Member.Name.Substring(1);
+        }
+
+        private static object GetFieldValue(
+            KeyValuePair<YamlNode, YamlNode> fieldNodePair, FieldContext fieldContext, IErrorReporter errorReporter)
+        {
+            if (fieldContext.CustomMapperFunc != null)
+            {
+                return fieldContext.CustomMapperFunc(fieldNodePair.Value.ToString(), fieldNodePair, errorReporter);
+            }
+
+            var propertyType = Nullable.GetUnderlyingType(fieldContext.PropertyInfo.PropertyType) ?? fieldContext.PropertyInfo.PropertyType;
+            if (propertyType.IsEnum)
+            {
+                var parseSucceeded = System.Enum.TryParse(
+                    propertyType, fieldNodePair.Value.ToString(), out var enumValue);
+
+                if (!parseSucceeded)
+                {
+                    errorReporter.ReportError(fieldNodePair.Value, $"'{fieldNodePair.Value}' is not a valid value for '{fieldNodePair.Key}'.");
+                }
+
+                return enumValue;
+            }
+            
+            if (typeof(IDictionary<string, string>).IsAssignableFrom(propertyType))
+            {
+                return ((YamlMappingNode)fieldNodePair.Value).GetDictionary();
+            }
+
+            if (propertyType == typeof(TimeSpan))
+            {
+                var parseSucceeded = TimeSpan.TryParse(fieldNodePair.Value.ToString(), out var timeSpanValue);
+                if (!parseSucceeded)
+                {
+                    errorReporter.ReportError(fieldNodePair.Value, $"'{fieldNodePair.Value}' is not a valid value for '{fieldNodePair.Key}'. The value must be in the format 'hh:mm:ss'.");
+                }
+
+                return timeSpanValue;
+            }
+
+            try
+            {
+                return Convert.ChangeType(fieldNodePair.Value.ToString(), fieldContext.PropertyInfo.PropertyType);
+            }
+            catch (FormatException)
+            {
+                errorReporter.ReportError(fieldNodePair.Value, $"'{fieldNodePair.Value}' is not a valid value for '{fieldNodePair.Key}'. The value must be of type {fieldContext.PropertyInfo.PropertyType}.");
+            }
+
+            return null;
+        }
+
+        private class FieldContext
+        {
+            public FieldContext(PropertyInfo propertyInfo, bool isRequired, object defaultValue, Func<string, KeyValuePair<YamlNode, YamlNode>, IErrorReporter, object> customMapperFunc)
+            {
+                CustomMapperFunc = customMapperFunc;
+                PropertyInfo = propertyInfo;
+                IsRequired = isRequired;
+                DefaultValue = defaultValue;
+            }
+
+            public bool HasBeenSet { get; private set; }
+            public PropertyInfo PropertyInfo { get; }
+            public bool IsRequired { get; }
+            public object DefaultValue { get; }
+            public Func<string, KeyValuePair<YamlNode, YamlNode>, IErrorReporter, object> CustomMapperFunc { get; }
+
+            public void SetValue(TObject target, object value)
+            {
+                PropertyInfo.SetValue(target, value);
+                HasBeenSet = true;
+            }
+
+            public void SetDefaultValue(TObject target)
+            {
+                PropertyInfo.SetValue(target, DefaultValue);
+            }
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/ErrorReporter.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/ErrorReporter.cs
@@ -1,0 +1,15 @@
+using YamlDotNet.RepresentationModel;
+
+namespace Promitor.Core.Scraping.Configuration.Serialization
+{
+    public class ErrorReporter : IErrorReporter
+    {
+        public void ReportError(YamlNode node, string message)
+        {
+        }
+
+        public void ReportWarning(YamlNode node, string message)
+        {
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/IDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/IDeserializer.cs
@@ -7,20 +7,22 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
     /// An object that can deserialize a yaml node into an object.
     /// </summary>
     /// <typeparam name="TObject">The type of object that can be deserialized.</typeparam>
-    public interface IDeserializer<TObject>
+    public interface IDeserializer<TObject> where TObject: new()
     {
         /// <summary>
         /// Deserializes the specified node.
         /// </summary>
         /// <param name="node">The node to deserialize.</param>
+        /// <param name="errorReporter">Used to report deserialization errors.</param>
         /// <returns>The deserialized object.</returns>
-        TObject Deserialize(YamlMappingNode node);
+        TObject Deserialize(YamlMappingNode node, IErrorReporter errorReporter);
 
         /// <summary>
         /// Deserializes an array of elements.
         /// </summary>
         /// <param name="node">The node to deserialize.</param>
+        /// <param name="errorReporter">Used to report deserialization errors.</param>
         /// <returns>The deserialized objects.</returns>
-        List<TObject> Deserialize(YamlSequenceNode node);
+        List<TObject> Deserialize(YamlSequenceNode node, IErrorReporter errorReporter);
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/IErrorReporter.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/IErrorReporter.cs
@@ -1,0 +1,24 @@
+﻿using YamlDotNet.RepresentationModel;
+
+namespace Promitor.Core.Scraping.Configuration.Serialization
+{
+    /// <summary>
+    /// Used to report errors discovered during the deserialization process.
+    /// </summary>
+    public interface IErrorReporter
+    {
+        /// <summary>
+        /// Reports an error.
+        /// </summary>
+        /// <param name="node">The node containing the error / that should be highlighted to the user.</param>
+        /// <param name="message">The error message.</param>
+        void ReportError(YamlNode node, string message);
+
+        /// <summary>
+        /// Reports a warning (i.e. something that doesn't prevent Promitor from functioning).
+        /// </summary>
+        /// <param name="node">The node containing the error / that should be highlighted to the user.</param>
+        /// <param name="message">The error message.</param>
+        void ReportWarning(YamlNode node, string message);
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/YamlMappingNodeExtensions.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/YamlMappingNodeExtensions.cs
@@ -41,6 +41,24 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
         }
 
         /// <summary>
+        /// Gets the contents of the node.
+        /// </summary>
+        /// <param name="node">The node containing the property.</param>
+        /// <param name="propertyName">The name of the property.</param>
+        /// <returns>The child items of the property as a dictionary.</returns>
+        public static Dictionary<string, string> GetDictionary(this YamlMappingNode node)
+        {
+            var result = new Dictionary<string, string>();
+
+            foreach (var (key, value) in node.Children)
+            {
+                result[key.ToString()] = value.ToString();
+            }
+
+            return result;
+        }
+
+        /// <summary>
         /// Gets the contents of the specified property as a dictionary.
         /// </summary>
         /// <param name="node">The node containing the property.</param>
@@ -50,14 +68,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
         {
             if (node.Children.TryGetValue(propertyName, out var propertyNode))
             {
-                var result = new Dictionary<string, string>();
-
-                foreach (var (key, value) in ((YamlMappingNode) propertyNode).Children)
-                {
-                    result[key.ToString()] = value.ToString();
-                }
-
-                return result;
+                return GetDictionary(((YamlMappingNode)propertyNode));
             }
 
             return null;
@@ -86,14 +97,15 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
         /// <param name="node">The yaml node.</param>
         /// <param name="propertyName">The name of the property to deserialize.</param>
         /// <param name="deserializer">The deserializer to use.</param>
+        /// <param name="errorReporter">Used to report information about the deserialization process.</param>
         /// <returns>The deserialized property, or null if the property does not exist.</returns>
         public static TObject DeserializeChild<TObject>(
-            this YamlMappingNode node, string propertyName, IDeserializer<TObject> deserializer)
-            where TObject: class
+            this YamlMappingNode node, string propertyName, IDeserializer<TObject> deserializer, IErrorReporter errorReporter)
+            where TObject: class, new()
         {
             if (node.Children.TryGetValue(propertyName, out var propertyNode))
             {
-                return deserializer.Deserialize((YamlMappingNode)propertyNode);
+                return deserializer.Deserialize((YamlMappingNode)propertyNode, errorReporter);
             }
 
             return null;

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AggregationDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AggregationDeserializer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
-using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
 {
@@ -9,27 +8,13 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
     {
         private const string IntervalTag = "interval";
 
-        private readonly TimeSpan _defaultAggregationInterval = TimeSpan.FromMinutes(5);
+        private static readonly TimeSpan DefaultAggregationInterval = TimeSpan.FromMinutes(5);
 
         public AggregationDeserializer(ILogger<AggregationDeserializer> logger) : base(logger)
         {
+            MapOptional(aggregation => aggregation.Interval, DefaultAggregationInterval);
         }
 
-        public override AggregationV1 Deserialize(YamlMappingNode node)
-        {
-            var interval = node.GetTimeSpan(IntervalTag);
-
-            var aggregation = new AggregationV1 {Interval = interval};
-
-            if (aggregation.Interval == null)
-            {
-                aggregation.Interval = _defaultAggregationInterval;
-                Logger.LogWarning(
-                    "No default aggregation was configured, falling back to {AggregationInterval}",
-                    aggregation.Interval?.ToString("g"));
-            }
-
-            return aggregation;
-        }
+        // TODO: Figure out if we want to make Interval required depending on the context
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureMetadataDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureMetadataDeserializer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
@@ -8,50 +9,37 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
 {
     public class AzureMetadataDeserializer : Deserializer<AzureMetadataV1>
     {
-        private const string CloudTag = "cloud";
-        private const string TenantIdTag = "tenantId";
-        private const string SubscriptionIdTag = "subscriptionId";
-        private const string ResourceGroupNameTag = "resourceGroupName";
-
         public AzureMetadataDeserializer(ILogger<AzureMetadataDeserializer> logger) : base(logger)
         {
+            MapRequired(metadata => metadata.TenantId);
+            MapRequired(metadata => metadata.SubscriptionId);
+            MapRequired(metadata => metadata.ResourceGroupName);
+            MapOptional(metadata => metadata.Cloud, AzureEnvironment.AzureGlobalCloud, DetermineAzureCloud);
+
         }
 
-        public override AzureMetadataV1 Deserialize(YamlMappingNode node)
+        private object DetermineAzureCloud(string rawAzureCloud, KeyValuePair<YamlNode, YamlNode> nodePair, IErrorReporter errorReporter)
         {
-            var metadata = new AzureMetadataV1();
-
-            var azureCloud = node.GetEnum<AzureCloudsV1>(CloudTag);
-            var cloud = DetermineAzureCloud(azureCloud);
-
-            metadata.TenantId = node.GetString(TenantIdTag);
-            metadata.SubscriptionId = node.GetString(SubscriptionIdTag);
-            metadata.ResourceGroupName = node.GetString(ResourceGroupNameTag);
-            metadata.Cloud = cloud;
-
-            return metadata;
-        }
-
-        private AzureEnvironment DetermineAzureCloud(AzureCloudsV1? azureCloud)
-        {
-            if (azureCloud == null)
+            if (System.Enum.TryParse<AzureCloudsV1>(rawAzureCloud, out var azureCloud))
             {
-                return AzureEnvironment.AzureGlobalCloud;
+                switch (azureCloud)
+                {
+                    case AzureCloudsV1.Global:
+                        return AzureEnvironment.AzureGlobalCloud;
+                    case AzureCloudsV1.China:
+                        return AzureEnvironment.AzureChinaCloud;
+                    case AzureCloudsV1.Germany:
+                        return AzureEnvironment.AzureGermanCloud;
+                    case AzureCloudsV1.UsGov:
+                        return AzureEnvironment.AzureUSGovernment;
+                }
+            }
+            else
+            {
+                errorReporter.ReportError(nodePair.Value, $"'{rawAzureCloud}' is not a valid value for 'cloud'.");
             }
 
-            switch (azureCloud)
-            {
-                case AzureCloudsV1.Global:
-                    return AzureEnvironment.AzureGlobalCloud;
-                case AzureCloudsV1.China:
-                    return AzureEnvironment.AzureChinaCloud;
-                case AzureCloudsV1.Germany:
-                    return AzureEnvironment.AzureGermanCloud;
-                case AzureCloudsV1.UsGov:
-                    return AzureEnvironment.AzureUSGovernment;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(azureCloud), azureCloud, $"{azureCloud} is not supported yet");
-            }
+            return null;
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureMetricConfigurationDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureMetricConfigurationDeserializer.cs
@@ -19,31 +19,31 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
             _aggregationDeserializer = aggregationDeserializer;
         }
 
-        public override AzureMetricConfigurationV1 Deserialize(YamlMappingNode node)
+        public override AzureMetricConfigurationV1 Deserialize(YamlMappingNode node, IErrorReporter errorReporter)
         {
             return new AzureMetricConfigurationV1
             {
                 MetricName = node.GetString(MetricNameTag),
-                Dimension = DeserializeDimension(node),
-                Aggregation = DeserializeAggregation(node)
+                Dimension = DeserializeDimension(node, errorReporter),
+                Aggregation = DeserializeAggregation(node, errorReporter)
             };
         }
 
-        private MetricAggregationV1 DeserializeAggregation(YamlMappingNode node)
+        private MetricAggregationV1 DeserializeAggregation(YamlMappingNode node, IErrorReporter errorReporter)
         {
             if (node.Children.TryGetValue(AggregationTag, out var aggregationNode))
             {
-                return _aggregationDeserializer.Deserialize((YamlMappingNode)aggregationNode);
+                return _aggregationDeserializer.Deserialize((YamlMappingNode) aggregationNode, errorReporter);
             }
 
             return null;
         }
 
-        private MetricDimensionV1 DeserializeDimension(YamlMappingNode node)
+        private MetricDimensionV1 DeserializeDimension(YamlMappingNode node, IErrorReporter errorReporter)
         {
             if (node.Children.TryGetValue(DimensionTag, out var aggregationNode))
             {
-                return _dimensionDeserializer.Deserialize((YamlMappingNode)aggregationNode);
+                return _dimensionDeserializer.Deserialize((YamlMappingNode)aggregationNode, errorReporter);
             }
 
             return null;

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/MetricAggregationDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/MetricAggregationDeserializer.cs
@@ -14,7 +14,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
         {
         }
 
-        public override MetricAggregationV1 Deserialize(YamlMappingNode node)
+        public override MetricAggregationV1 Deserialize(YamlMappingNode node, IErrorReporter errorReporter)
         {
             var aggregationType = node.GetEnum<AggregationType>(TypeTag);
 

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/MetricDefaultsDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/MetricDefaultsDeserializer.cs
@@ -21,12 +21,12 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
             _scrapingDeserializer = scrapingDeserializer;
         }
 
-        public override MetricDefaultsV1 Deserialize(YamlMappingNode node)
+        public override MetricDefaultsV1 Deserialize(YamlMappingNode node, IErrorReporter errorReporter)
         {
             var defaults = new MetricDefaultsV1();
 
-            defaults.Aggregation = node.DeserializeChild(AggregationTag, _aggregationDeserializer);
-            defaults.Scraping = node.DeserializeChild(ScrapingTag, _scrapingDeserializer);
+            defaults.Aggregation = node.DeserializeChild(AggregationTag, _aggregationDeserializer, errorReporter);
+            defaults.Scraping = node.DeserializeChild(ScrapingTag, _scrapingDeserializer, errorReporter);
 
             return defaults;
         }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/MetricDefinitionDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/MetricDefinitionDeserializer.cs
@@ -29,7 +29,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
             _azureResourceDeserializerFactory = azureResourceDeserializerFactory;
         }
 
-        public override MetricDefinitionV1 Deserialize(YamlMappingNode node)
+        public override MetricDefinitionV1 Deserialize(YamlMappingNode node, IErrorReporter errorReporter)
         {
             var name = node.GetString(NameTag);
             var description = node.GetString(DescriptionTag);
@@ -44,38 +44,38 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
                 Labels = labels
             };
 
-            DeserializeAzureMetricConfiguration(node, metricDefinition);
-            DeserializeScraping(node, metricDefinition);
-            DeserializeMetrics(node, metricDefinition);
+            DeserializeAzureMetricConfiguration(node, metricDefinition, errorReporter);
+            DeserializeScraping(node, metricDefinition, errorReporter);
+            DeserializeMetrics(node, metricDefinition, errorReporter);
 
             return metricDefinition;
         }
 
-        private void DeserializeAzureMetricConfiguration(YamlMappingNode node, MetricDefinitionV1 metricDefinition)
+        private void DeserializeAzureMetricConfiguration(YamlMappingNode node, MetricDefinitionV1 metricDefinition, IErrorReporter errorReporter)
         {
             if (node.Children.TryGetValue(AzureMetricConfigurationTag, out var configurationNode))
             {
                 metricDefinition.AzureMetricConfiguration =
-                    _azureMetricConfigurationDeserializer.Deserialize((YamlMappingNode) configurationNode);
+                    _azureMetricConfigurationDeserializer.Deserialize((YamlMappingNode) configurationNode, errorReporter);
             }
         }
 
-        private void DeserializeScraping(YamlMappingNode node, MetricDefinitionV1 metricDefinition)
+        private void DeserializeScraping(YamlMappingNode node, MetricDefinitionV1 metricDefinition, IErrorReporter errorReporter)
         {
             if (node.Children.TryGetValue(ScrapingTag, out var scrapingNode))
             {
-                metricDefinition.Scraping = _scrapingDeserializer.Deserialize((YamlMappingNode)scrapingNode);
+                metricDefinition.Scraping = _scrapingDeserializer.Deserialize((YamlMappingNode)scrapingNode, errorReporter);
             }
         }
 
-        private void DeserializeMetrics(YamlMappingNode node, MetricDefinitionV1 metricDefinition)
+        private void DeserializeMetrics(YamlMappingNode node, MetricDefinitionV1 metricDefinition, IErrorReporter errorReporter)
         {
             if (metricDefinition.ResourceType != null &&
                 metricDefinition.ResourceType != ResourceType.NotSpecified &&
                 node.Children.TryGetValue(ResourcesTag, out var metricsNode))
             {
                 var resourceDeserializer = _azureResourceDeserializerFactory.GetDeserializerFor(metricDefinition.ResourceType.Value);
-                metricDefinition.Resources = resourceDeserializer.Deserialize((YamlSequenceNode)metricsNode);
+                metricDefinition.Resources = resourceDeserializer.Deserialize((YamlSequenceNode)metricsNode, errorReporter);
             }
         }
     }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/MetricDimensionDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/MetricDimensionDeserializer.cs
@@ -13,7 +13,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
         {
         }
 
-        public override MetricDimensionV1 Deserialize(YamlMappingNode node)
+        public override MetricDimensionV1 Deserialize(YamlMappingNode node, IErrorReporter errorReporter)
         {
             return new MetricDimensionV1
             {

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/ScrapingDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/ScrapingDeserializer.cs
@@ -12,7 +12,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
         {
         }
 
-        public override ScrapingV1 Deserialize(YamlMappingNode node)
+        public override ScrapingV1 Deserialize(YamlMappingNode node, IErrorReporter errorReporter)
         {
             var scraping = new ScrapingV1();
 

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/SecretDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/SecretDeserializer.cs
@@ -13,7 +13,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
         {
         }
 
-        public override SecretV1 Deserialize(YamlMappingNode node)
+        public override SecretV1 Deserialize(YamlMappingNode node, IErrorReporter errorReporter)
         {
             var rawValue = node.GetString(RawValueTag);
             var environmentVariable = node.GetString(EnvironmentVariableTag);

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/V1Deserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/V1Deserializer.cs
@@ -22,13 +22,13 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
             _metricsDeserializer = metricsDeserializer;
         }
 
-        public override MetricsDeclarationV1 Deserialize(YamlMappingNode rootNode)
+        public override MetricsDeclarationV1 Deserialize(YamlMappingNode rootNode, IErrorReporter errorReporter)
         {
             ValidateVersion(rootNode);
 
-            var azureMetadata = DeserializeAzureMetadata(rootNode);
-            var metricDefaults = DeserializeMetricDefaults(rootNode);
-            var metrics = DeserializeMetrics(rootNode);
+            var azureMetadata = DeserializeAzureMetadata(rootNode, errorReporter);
+            var metricDefaults = DeserializeMetricDefaults(rootNode, errorReporter);
+            var metrics = DeserializeMetrics(rootNode, errorReporter);
 
             return new MetricsDeclarationV1
             {
@@ -53,31 +53,31 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
             }
         }
 
-        private AzureMetadataV1 DeserializeAzureMetadata(YamlMappingNode rootNode)
+        private AzureMetadataV1 DeserializeAzureMetadata(YamlMappingNode rootNode, IErrorReporter errorReporter)
         {
             if (rootNode.Children.TryGetValue("azureMetadata", out var azureMetadataNode))
             {
-                return _azureMetadataDeserializer.Deserialize((YamlMappingNode)azureMetadataNode);
+                return _azureMetadataDeserializer.Deserialize((YamlMappingNode)azureMetadataNode, errorReporter);
             }
 
             return null;
         }
 
-        private MetricDefaultsV1 DeserializeMetricDefaults(YamlMappingNode rootNode)
+        private MetricDefaultsV1 DeserializeMetricDefaults(YamlMappingNode rootNode, IErrorReporter errorReporter)
         {
             if (rootNode.Children.TryGetValue("metricDefaults", out var defaultsNode))
             {
-                return _defaultsDeserializer.Deserialize((YamlMappingNode)defaultsNode);
+                return _defaultsDeserializer.Deserialize((YamlMappingNode)defaultsNode, errorReporter);
             }
 
             return null;
         }
 
-        private List<MetricDefinitionV1> DeserializeMetrics(YamlMappingNode rootNode)
+        private List<MetricDefinitionV1> DeserializeMetrics(YamlMappingNode rootNode, IErrorReporter errorReporter)
         {
             if (rootNode.Children.TryGetValue("metrics", out var metricsNode))
             {
-                return _metricsDeserializer.Deserialize((YamlSequenceNode)metricsNode);
+                return _metricsDeserializer.Deserialize((YamlSequenceNode)metricsNode, errorReporter);
             }
 
             return null;

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ApiManagementDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ApiManagementDeserializer.cs
@@ -17,7 +17,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         {
         }
 
-        protected override ApiManagementResourceV1 DeserializeResource(YamlMappingNode node)
+        protected override ApiManagementResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
         {
             var instanceName = node.GetString("instanceName");
             var locationName = node.GetString("locationName");

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/AppPlanDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/AppPlanDeserializer.cs
@@ -12,7 +12,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         {
         }
 
-        protected override AppPlanResourceV1 DeserializeResource(YamlMappingNode node)
+        protected override AppPlanResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
         {
             var appPlanName = node.GetString(AppPlanNameTag);
 

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/BlobStorageDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/BlobStorageDeserializer.cs
@@ -10,9 +10,9 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         {
         }
 
-        protected override StorageAccountResourceV1 DeserializeResource(YamlMappingNode node)
+        protected override StorageAccountResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
         {
-            var storageAccountResource = base.DeserializeResource(node);
+            var storageAccountResource = base.DeserializeResource(node, errorReporter);
 
             return new BlobStorageResourceV1(storageAccountResource);
         }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ContainerInstanceDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ContainerInstanceDeserializer.cs
@@ -12,7 +12,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         {
         }
 
-        protected override ContainerInstanceResourceV1 DeserializeResource(YamlMappingNode node)
+        protected override ContainerInstanceResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
         {
             var containerGroup = node.GetString(ContainerGroupTag);
 

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ContainerRegistryDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ContainerRegistryDeserializer.cs
@@ -12,7 +12,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         {
         }
 
-        protected override ContainerRegistryResourceV1 DeserializeResource(YamlMappingNode node)
+        protected override ContainerRegistryResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
         {
             var registryName = node.GetString(RegistryNameTag);
 

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/CosmosDbDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/CosmosDbDeserializer.cs
@@ -12,7 +12,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         {
         }
 
-        protected override CosmosDbResourceV1 DeserializeResource(YamlMappingNode node)
+        protected override CosmosDbResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
         {
             var databaseName = node.GetString(DatabaseNameTag);
 

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/FileStorageDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/FileStorageDeserializer.cs
@@ -10,9 +10,9 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         {
         }
 
-        protected override StorageAccountResourceV1 DeserializeResource(YamlMappingNode node)
+        protected override StorageAccountResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
         {
-            var storageAccountResource = base.DeserializeResource(node);
+            var storageAccountResource = base.DeserializeResource(node, errorReporter);
 
             return new FileStorageResourceV1(storageAccountResource);
         }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/FunctionAppDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/FunctionAppDeserializer.cs
@@ -13,7 +13,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         {
         }
 
-        protected override FunctionAppResourceV1 DeserializeResource(YamlMappingNode node)
+        protected override FunctionAppResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
         {
             var functionAppName = node.GetString(FunctionAppNameTag);
             var slotName = node.GetString(SlotNameTag);

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/GenericResourceDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/GenericResourceDeserializer.cs
@@ -13,7 +13,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         {
         }
 
-        protected override GenericResourceV1 DeserializeResource(YamlMappingNode node)
+        protected override GenericResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
         {
             var filter = node.GetString(FilterTag);
             var resourceUri = node.GetString(ResourceUriTag);

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/NetworkInterfaceDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/NetworkInterfaceDeserializer.cs
@@ -12,7 +12,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         {
         }
 
-        protected override NetworkInterfaceResourceV1 DeserializeResource(YamlMappingNode node)
+        protected override NetworkInterfaceResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
         {
             var networkInterfaceName = node.GetString(NetworkInterfaceNameTag);
 

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/PostgreSqlDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/PostgreSqlDeserializer.cs
@@ -12,7 +12,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         {
         }
 
-        protected override PostgreSqlResourceV1 DeserializeResource(YamlMappingNode node)
+        protected override PostgreSqlResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
         {
             var serverName = node.GetString(ServerNameTag);
 

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/RedisCacheDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/RedisCacheDeserializer.cs
@@ -12,7 +12,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         {
         }
 
-        protected override RedisCacheResourceV1 DeserializeResource(YamlMappingNode node)
+        protected override RedisCacheResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
         {
             var cacheName = node.GetString(CacheNameTag);
 

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ResourceDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ResourceDeserializer.cs
@@ -17,9 +17,9 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         {
         }
 
-        public override AzureResourceDefinitionV1 Deserialize(YamlMappingNode node)
+        public override AzureResourceDefinitionV1 Deserialize(YamlMappingNode node, IErrorReporter errorReporter)
         {
-            var resource = DeserializeResource(node);
+            var resource = DeserializeResource(node, errorReporter);
 
             resource.ResourceGroupName = node.GetString(ResourceGroupNameTag);
 
@@ -31,7 +31,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         ///     object with all its custom properties populated.
         /// </summary>
         /// <param name="node">The yaml node.</param>
+        /// <param name="errorReporter">Used to report errors with the deserialization process.</param>
         /// <returns>The deserialized object.</returns>
-        protected abstract TResourceDefinition DeserializeResource(YamlMappingNode node);
+        protected abstract TResourceDefinition DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter);
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ServiceBusQueueDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ServiceBusQueueDeserializer.cs
@@ -13,7 +13,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         {
         }
 
-        protected override ServiceBusQueueResourceV1 DeserializeResource(YamlMappingNode node)
+        protected override ServiceBusQueueResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
         {
             var queueName = node.GetString(QueueNameTag);
             var @namespace = node.GetString(NamespaceTag);

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/SqlDatabaseDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/SqlDatabaseDeserializer.cs
@@ -17,9 +17,9 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         {
         }
 
-        protected override SqlServerResourceV1 DeserializeResource(YamlMappingNode node)
+        protected override SqlServerResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
         {
-            var sqlServerResource = base.DeserializeResource(node);
+            var sqlServerResource = base.DeserializeResource(node, errorReporter);
 
             return new SqlDatabaseResourceV1(sqlServerResource)
             {

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/SqlManagedInstanceDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/SqlManagedInstanceDeserializer.cs
@@ -17,7 +17,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         {
         }
 
-        protected override SqlManagedInstanceResourceV1 DeserializeResource(YamlMappingNode node)
+        protected override SqlManagedInstanceResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
         {
             var instanceName = node.GetString("instanceName");
 

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/SqlServerDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/SqlServerDeserializer.cs
@@ -17,7 +17,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         {
         }
 
-        protected override SqlServerResourceV1 DeserializeResource(YamlMappingNode node)
+        protected override SqlServerResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
         {
             var serverName = node.GetString("serverName");
 

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/StorageAccountDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/StorageAccountDeserializer.cs
@@ -12,7 +12,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         {
         }
 
-        protected override StorageAccountResourceV1 DeserializeResource(YamlMappingNode node)
+        protected override StorageAccountResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
         {
             var accountName = node.GetString(AccountNameTag);
 

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/StorageQueueDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/StorageQueueDeserializer.cs
@@ -17,12 +17,12 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
             _secretDeserializer = secretDeserializer;
         }
 
-        protected override StorageAccountResourceV1 DeserializeResource(YamlMappingNode node)
+        protected override StorageAccountResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
         {
-            var storageAccountResource = base.DeserializeResource(node);
+            var storageAccountResource = base.DeserializeResource(node, errorReporter);
 
             var queueName = node.GetString(QueueNameTag);
-            var sasToken = node.DeserializeChild(SasTokenTag, _secretDeserializer);
+            var sasToken = node.DeserializeChild(SasTokenTag, _secretDeserializer, errorReporter);
 
             var storageQueueResource = new StorageQueueResourceV1(storageAccountResource)
             {

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/VirtualMachineDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/VirtualMachineDeserializer.cs
@@ -12,7 +12,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         {
         }
 
-        protected override VirtualMachineResourceV1 DeserializeResource(YamlMappingNode node)
+        protected override VirtualMachineResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
         {
             var virtualMachineName = node.GetString(VirtualMachineNameTag);
 

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/VirtualMachineScaleSetDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/VirtualMachineScaleSetDeserializer.cs
@@ -12,7 +12,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         {
         }
 
-        protected override VirtualMachineScaleSetResourceV1 DeserializeResource(YamlMappingNode node)
+        protected override VirtualMachineScaleSetResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
         {
             var scaleSetName = node.GetString(ScaleSetNameTag);
 

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/WebAppDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/WebAppDeserializer.cs
@@ -13,7 +13,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         {
         }
 
-        protected override WebAppResourceV1 DeserializeResource(YamlMappingNode node)
+        protected override WebAppResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
         {
             var webAppName = node.GetString(WebAppNameTag);
             var slotName = node.GetString(SlotNameTag);

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/DeserializerTests/DeserializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/DeserializerTests/DeserializationTests.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Promitor.Core.Scraping.Configuration.Serialization;
+using Xunit;
+using YamlDotNet.RepresentationModel;
+
+namespace Promitor.Scraper.Tests.Unit.Serialization.DeserializerTests
+{
+    public class DeserializationTests
+    {
+        private static readonly TimeSpan DefaultInterval = TimeSpan.FromMinutes(5);
+
+        private readonly Mock<IErrorReporter> errorReporter = new Mock<IErrorReporter>();
+        private readonly RegistrationConfigDeserializer deserializer = new RegistrationConfigDeserializer();
+
+        [Fact]
+        public void Deserialize_RequiredFieldSupplied_SetsField()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("name: Promitor");
+
+            // Act
+            var result = deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            Assert.Equal("Promitor", result.Name);
+        }
+
+        [Fact]
+        public void Deserialize_OptionalFieldSupplied_SetsField()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("town: Glasgow");
+
+            // Act
+            var result = deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            Assert.Equal("Glasgow", result.Town);
+        }
+
+        [Fact]
+        public void Deserialize_StringFieldNotSupplied_Null()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("age: 17");
+
+            // Act
+            var result = deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            Assert.Null(result.Name);
+        }
+
+        [Fact]
+        public void Deserialize_IntFieldSupplied_SetsField()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("age: 22");
+
+            // Act
+            var result = deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            Assert.Equal(22, result.Age);
+        }
+
+        [Fact]
+        public void Deserialize_IntFieldNotSupplied_SetsFieldTo0()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("name: Promitor");
+
+            // Act
+            var result = deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            Assert.Equal(0, result.Age);
+        }
+
+        [Fact]
+        public void Deserialize_EnumFieldSupplied_SetsField()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("day: Monday");
+
+            // Act
+            var result = deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            Assert.Equal(DayOfWeek.Monday, result.Day);
+        }
+
+        [Fact]
+        public void Deserialize_NullableEnumFieldSupplied_SetsField()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("nullableDay: Monday");
+
+            // Act
+            var result = deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            Assert.Equal(DayOfWeek.Monday, result.NullableDay);
+        }
+
+        [Fact]
+        public void Deserialize_EnumFieldNotSupplied_SetsDefault()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("name: Promitor");
+
+            // Act
+            var result = deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            Assert.Equal(default(DayOfWeek), result.Day);
+        }
+
+        [Fact]
+        public void Deserialize_DictionarySupplied_DeserializesDictionary()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode(
+@"classes:
+    first: maths
+    second: chemistry
+    third: art");
+
+            // Act
+            var result = deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            var expectedClasses = new Dictionary<string, string>
+            {
+                { "first", "maths" },
+                { "second", "chemistry" },
+                { "third", "art" }
+            };
+            Assert.Equal(expectedClasses, result.Classes);
+        }
+
+        [Fact]
+        public void Deserialize_TimeSpanFieldSupplied_SetsField()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("interval: 01:02:03");
+
+            // Act
+            var result = deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            Assert.Equal(new TimeSpan(1, 2, 3), result.Interval);
+        }
+
+        [Fact]
+        public void Deserialize_MapOptional_CanSpecifyDefaultValue()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("name: Promitor");
+
+            // Act
+            var result = deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            Assert.Equal(DefaultInterval, result.DefaultedInterval);
+        }
+
+        [Fact]
+        public void Deserialize_NullableTimeSpanFieldSupplied_SetsField()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("nullableInterval: 01:02:03");
+
+            // Act
+            var result = deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            Assert.Equal(new TimeSpan(1, 2, 3), result.NullableInterval);
+        }
+
+        [Fact]
+        public void Deserialize_CustomMappingFunctionSupplied_UsesCustomMappingFunction()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("invertedProperty: false");
+
+            // Act
+            var result = deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            Assert.True(result.InvertedProperty);
+        }
+
+        // TODO: Test for duplicate field registration
+
+        private class RegistrationConfig
+        {
+            public string Name { get; set; }
+            public int Age { get; set; }
+            public DayOfWeek Day { get; set; }
+            public DayOfWeek? NullableDay { get; set; }
+            public Dictionary<string, string> Classes { get; set; }
+            public string Town { get; set; }
+            public TimeSpan Interval { get; set; }
+            public TimeSpan DefaultedInterval { get; set; }
+            public TimeSpan? NullableInterval { get; set; }
+            public bool InvertedProperty { get; set; }
+        }
+
+        private class RegistrationConfigDeserializer: Deserializer<RegistrationConfig>
+        {
+            public RegistrationConfigDeserializer() : base(NullLogger.Instance)
+            {
+                MapRequired(t => t.Name);
+                MapRequired(t => t.Age);
+                MapRequired(t => t.Day);
+                MapOptional(t => t.NullableDay);
+                MapRequired(t => t.Classes);
+                MapOptional(t => t.Town);
+                MapOptional(t => t.Interval);
+                MapOptional(t => t.DefaultedInterval, DefaultInterval);
+                MapOptional(t => t.NullableInterval);
+                MapOptional(t => t.InvertedProperty, false, InvertBooleanString);
+            }
+
+            private static object InvertBooleanString(string value, KeyValuePair<YamlNode, YamlNode> nodePair, IErrorReporter errorReporter)
+            {
+                var boolValue = bool.Parse(value);
+
+                return !boolValue;
+            }
+        }
+    }
+}

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/DeserializerTests/ValidationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/DeserializerTests/ValidationTests.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Linq;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Promitor.Core.Scraping.Configuration.Serialization;
+using Promitor.Scraper.Tests.Unit.Serialization;
+using Xunit;
+using YamlDotNet.RepresentationModel;
+
+namespace Promitor.Scraper.Tests.Unit.Serialization.DeserializerTests
+{
+    public class ValidationTests
+    {
+        private readonly Mock<IErrorReporter> errorReporter = new Mock<IErrorReporter>();
+        private readonly TestDeserializer deserializer = new TestDeserializer();
+        
+        [Fact]
+        public void Deserialize_RequiredFieldMissing_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("age: 20");
+
+            // Act
+            var result = deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            errorReporter.Verify(r => r.ReportError(node, "'name' is a required field but was not found."));
+        }
+        
+        [Fact]
+        public void Deserialize_RequiredFieldProvided_DoesNotReportError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("name: Promitor");
+
+            // Act
+            var result = deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            errorReporter.Verify(
+                r => r.ReportError(node, It.Is<string>(message => message.Contains("name"))), Times.Never);
+        }
+        
+        [Fact]
+        public void Deserialize_OptionalFieldMissing_DoesNotReportError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("name: Promitor");
+
+            // Act
+            var result = deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            errorReporter.Verify(
+                r => r.ReportError(It.IsAny<YamlNode>(), It.Is<string>(message => message.Contains("age"))), Times.Never);
+        }
+
+        [Fact]
+        public void Deserialize_UnknownFields_ReportsWarnings()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode(
+@"city: Glasgow
+country: Scotland");
+
+            // Act
+            var result = deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            var cityTagNode = node.Children.Single(c => c.Key.ToString() == "city").Key;
+            var countryTagNode = node.Children.Single(c => c.Key.ToString() == "country").Key;
+            
+            errorReporter.Verify(r => r.ReportWarning(cityTagNode, "Unknown field 'city'."));
+            errorReporter.Verify(r => r.ReportWarning(countryTagNode, "Unknown field 'country'."));
+        }
+
+        [Fact]
+        public void Deserialize_EnumValueInvalid_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("day: Sundag");
+
+            // Act
+            var result = deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            var dayValueNode = node.Children.Single(c => c.Key.ToString() == "day").Value;
+            
+            errorReporter.Verify(r => r.ReportError(dayValueNode, "'Sundag' is not a valid value for 'day'."));
+        }
+
+        [Fact]
+        public void Deserialize_IntValueInvalid_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("age: twenty");
+
+            // Act
+            var result = deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            var dayValueNode = node.Children.Single(c => c.Key.ToString() == "age").Value;
+            
+            errorReporter.Verify(r => r.ReportError(dayValueNode, $"'twenty' is not a valid value for 'age'. The value must be of type {typeof(int)}."));
+        }
+
+        [Fact]
+        public void Deserialize_TimeSpanValueInvalid_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("interval: twenty");
+
+            // Act
+            var result = deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            var dayValueNode = node.Children.Single(c => c.Key.ToString() == "interval").Value;
+            
+            errorReporter.Verify(r => r.ReportError(dayValueNode, $"'twenty' is not a valid value for 'interval'. The value must be in the format 'hh:mm:ss'."));
+        }
+
+        // TODO: Check for invalid formats (crontab expression, timespan, etc)
+        // TODO: Add a test to make sure that the error is against the mapping node rather than its value for missing required fields
+
+        private class TestConfigObject
+        {
+            public string Name { get; set; }
+            public int Age { get; set; }
+            public DayOfWeek Day { get; set; }
+            public TimeSpan Interval { get; set; }
+        }
+
+        private class TestDeserializer: Deserializer<TestConfigObject>
+        {
+            public TestDeserializer() : base(NullLogger.Instance)
+            {
+                MapRequired(t => t.Name);
+                MapOptional(t => t.Age);
+                MapOptional(t => t.Day);
+                MapOptional(t => t.Interval);
+            }
+        }
+    }
+}

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/YamlMappingNodeExtensionTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/YamlMappingNodeExtensionTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 using Promitor.Core.Scraping.Configuration.Serialization;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Core;
 using Xunit;
@@ -139,6 +140,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization
         public void DeserializeChild_PropertySpecified_DeserializesChild()
         {
             // Arrange
+            var errorReporter = new Mock<IErrorReporter>();
             const string yamlText =
 @"aggregation:
     interval: 00:05:00";
@@ -146,7 +148,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization
             var deserializer = new AggregationDeserializer(NullLogger<AggregationDeserializer>.Instance);
 
             // Act
-            var aggregation = node.DeserializeChild("aggregation", deserializer);
+            var aggregation = node.DeserializeChild("aggregation", deserializer, errorReporter.Object);
 
             // Assert
             Assert.Equal(TimeSpan.FromMinutes(5), aggregation.Interval);
@@ -156,11 +158,12 @@ namespace Promitor.Scraper.Tests.Unit.Serialization
         public void DeserializeChild_PropertyNotSpecified_Null()
         {
             // Arrange
+            var errorReporter = new Mock<IErrorReporter>();
             var node = YamlUtils.CreateYamlNode(@"time: 00:05:30");
             var deserializer = new AggregationDeserializer(NullLogger<AggregationDeserializer>.Instance);
 
             // Act
-            var aggregation = node.DeserializeChild("aggregation", deserializer);
+            var aggregation = node.DeserializeChild("aggregation", deserializer, errorReporter.Object);
 
             // Assert
             Assert.Null(aggregation);

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Core/AzureMetricConfigurationDeserializerTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Core/AzureMetricConfigurationDeserializerTests.cs
@@ -15,6 +15,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Core
         private readonly AzureMetricConfigurationDeserializer _deserializer;
         private readonly Mock<IDeserializer<MetricDimensionV1>> _dimensionDeserializer;
         private readonly Mock<IDeserializer<MetricAggregationV1>> _aggregationDeserializer;
+        private readonly Mock<IErrorReporter> _errorReporter = new Mock<IErrorReporter>();
 
         public AzureMetricConfigurationDeserializerTests()
         {
@@ -54,10 +55,10 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Core
             var aggregationNode = (YamlMappingNode)node.Children["aggregation"];
 
             var aggregation = new MetricAggregationV1();
-            _aggregationDeserializer.Setup(d => d.Deserialize(aggregationNode)).Returns(aggregation);
+            _aggregationDeserializer.Setup(d => d.Deserialize(aggregationNode, _errorReporter.Object)).Returns(aggregation);
 
             // Act
-            var config = _deserializer.Deserialize(node);
+            var config = _deserializer.Deserialize(node, _errorReporter.Object);
 
             // Assert
             Assert.Same(aggregation, config.Aggregation);
@@ -74,10 +75,10 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Core
             var dimensionNode = (YamlMappingNode)node.Children["dimension"];
 
             var dimension = new MetricDimensionV1();
-            _dimensionDeserializer.Setup(d => d.Deserialize(dimensionNode)).Returns(dimension);
+            _dimensionDeserializer.Setup(d => d.Deserialize(dimensionNode, _errorReporter.Object)).Returns(dimension);
 
             // Act
-            var config = _deserializer.Deserialize(node);
+            var config = _deserializer.Deserialize(node, _errorReporter.Object);
 
             // Assert
             Assert.Same(dimension, config.Dimension);

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Core/MetricDefaultsDeserializerTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Core/MetricDefaultsDeserializerTests.cs
@@ -15,6 +15,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Core
         private readonly MetricDefaultsDeserializer _deserializer;
         private readonly Mock<IDeserializer<AggregationV1>> _aggregationDeserializer;
         private readonly Mock<IDeserializer<ScrapingV1>> _scrapingDeserializer;
+        private readonly Mock<IErrorReporter> _errorReporter = new Mock<IErrorReporter>();
 
         public MetricDefaultsDeserializerTests()
         {
@@ -37,10 +38,10 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Core
 
             var aggregationNode = (YamlMappingNode)node.Children["aggregation"];
             var aggregation = new AggregationV1();
-            _aggregationDeserializer.Setup(d => d.Deserialize(aggregationNode)).Returns(aggregation);
+            _aggregationDeserializer.Setup(d => d.Deserialize(aggregationNode, _errorReporter.Object)).Returns(aggregation);
 
             // Act
-            var defaults = _deserializer.Deserialize(node);
+            var defaults = _deserializer.Deserialize(node, _errorReporter.Object);
 
             // Assert
             Assert.Same(aggregation, defaults.Aggregation);
@@ -57,10 +58,10 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Core
             var node = (YamlMappingNode)YamlUtils.CreateYamlNode(yamlText).Children["metricDefaults"];
 
             // Act
-            _deserializer.Deserialize(node);
+            _deserializer.Deserialize(node, _errorReporter.Object);
 
             // Assert
-            _aggregationDeserializer.Verify(d => d.Deserialize(It.IsAny<YamlMappingNode>()), Times.Never);
+            _aggregationDeserializer.Verify(d => d.Deserialize(It.IsAny<YamlMappingNode>(), It.IsAny<IErrorReporter>()), Times.Never);
         }
 
         [Fact]
@@ -75,10 +76,10 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Core
 
             var scrapingNode = (YamlMappingNode)node.Children["scraping"];
             var scraping = new ScrapingV1();
-            _scrapingDeserializer.Setup(d => d.Deserialize(scrapingNode)).Returns(scraping);
+            _scrapingDeserializer.Setup(d => d.Deserialize(scrapingNode, _errorReporter.Object)).Returns(scraping);
 
             // Act
-            var defaults = _deserializer.Deserialize(node);
+            var defaults = _deserializer.Deserialize(node, _errorReporter.Object);
 
             // Assert
             Assert.Same(scraping, defaults.Scraping);
@@ -95,10 +96,11 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Core
             var node = (YamlMappingNode)YamlUtils.CreateYamlNode(yamlText).Children["metricDefaults"];
 
             // Act
-            _deserializer.Deserialize(node);
+            _deserializer.Deserialize(node, _errorReporter.Object);
 
             // Assert
-            _scrapingDeserializer.Verify(d => d.Deserialize(It.IsAny<YamlMappingNode>()), Times.Never);
+            _scrapingDeserializer.Verify(
+                d => d.Deserialize(It.IsAny<YamlMappingNode>(), It.IsAny<IErrorReporter>()), Times.Never);
         }
     }
 }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Core/MetricDefinitionDeserializerTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Core/MetricDefinitionDeserializerTests.cs
@@ -17,6 +17,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Core
         private readonly Mock<IDeserializer<AzureMetricConfigurationV1>> _azureMetricConfigurationDeserializer;
         private readonly Mock<IDeserializer<ScrapingV1>> _scrapingDeserializer;
         private readonly Mock<IAzureResourceDeserializerFactory> _resourceDeserializerFactory;
+        private readonly Mock<IErrorReporter> _errorReporter = new Mock<IErrorReporter>();
 
         private readonly MetricDefinitionDeserializer _deserializer;
 
@@ -116,10 +117,10 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Core
             var configurationNode = (YamlMappingNode)node.Children["azureMetricConfiguration"];
             var configuration = new AzureMetricConfigurationV1();
 
-            _azureMetricConfigurationDeserializer.Setup(d => d.Deserialize(configurationNode)).Returns(configuration);
+            _azureMetricConfigurationDeserializer.Setup(d => d.Deserialize(configurationNode, _errorReporter.Object)).Returns(configuration);
 
             // Act
-            var definition = _deserializer.Deserialize(node);
+            var definition = _deserializer.Deserialize(node, _errorReporter.Object);
 
             // Assert
             Assert.Same(configuration, definition.AzureMetricConfiguration);
@@ -133,10 +134,10 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Core
             var node = YamlUtils.CreateYamlNode(yamlText);
 
             _azureMetricConfigurationDeserializer.Setup(
-                d => d.Deserialize(It.IsAny<YamlMappingNode>())).Returns(new AzureMetricConfigurationV1());
+                d => d.Deserialize(It.IsAny<YamlMappingNode>(), It.IsAny<IErrorReporter>())).Returns(new AzureMetricConfigurationV1());
 
             // Act
-            var definition = _deserializer.Deserialize(node);
+            var definition = _deserializer.Deserialize(node, _errorReporter.Object);
 
             // Assert
             Assert.Null(definition.AzureMetricConfiguration);
@@ -153,10 +154,10 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Core
             var scrapingNode = (YamlMappingNode)node.Children["scraping"];
             var scraping = new ScrapingV1();
 
-            _scrapingDeserializer.Setup(d => d.Deserialize(scrapingNode)).Returns(scraping);
+            _scrapingDeserializer.Setup(d => d.Deserialize(scrapingNode, _errorReporter.Object)).Returns(scraping);
 
             // Act
-            var definition = _deserializer.Deserialize(node);
+            var definition = _deserializer.Deserialize(node, _errorReporter.Object);
 
             // Assert
             Assert.Same(scraping, definition.Scraping);
@@ -169,10 +170,11 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Core
             const string yamlText = "name: promitor_test_metric";
             var node = YamlUtils.CreateYamlNode(yamlText);
 
-            _scrapingDeserializer.Setup(d => d.Deserialize(It.IsAny<YamlMappingNode>())).Returns(new ScrapingV1());
+            _scrapingDeserializer.Setup(
+                d => d.Deserialize(It.IsAny<YamlMappingNode>(), It.IsAny<IErrorReporter>())).Returns(new ScrapingV1());
 
             // Act
-            var definition = _deserializer.Deserialize(node);
+            var definition = _deserializer.Deserialize(node, It.IsAny<IErrorReporter>());
 
             // Assert
             Assert.Null(definition.Scraping);
@@ -195,10 +197,10 @@ resources:
 
             var resources = new List<AzureResourceDefinitionV1>();
             resourceDeserializer.Setup(
-                d => d.Deserialize((YamlSequenceNode)node.Children["resources"])).Returns(resources);
+                d => d.Deserialize((YamlSequenceNode)node.Children["resources"], _errorReporter.Object)).Returns(resources);
 
             // Act
-            var definition = _deserializer.Deserialize(node);
+            var definition = _deserializer.Deserialize(node, _errorReporter.Object);
 
             // Assert
             Assert.Same(resources, definition.Resources);
@@ -220,10 +222,10 @@ resources:
 
             var resources = new List<AzureResourceDefinitionV1>();
             resourceDeserializer.Setup(
-                d => d.Deserialize((YamlSequenceNode)node.Children["resources"])).Returns(resources);
+                d => d.Deserialize((YamlSequenceNode)node.Children["resources"], _errorReporter.Object)).Returns(resources);
 
             // Act
-            var definition = _deserializer.Deserialize(node);
+            var definition = _deserializer.Deserialize(node, _errorReporter.Object);
 
             // Assert
             Assert.Null(definition.Resources);

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Core/V1DeserializerTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Core/V1DeserializerTests.cs
@@ -17,6 +17,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Core
         private readonly Mock<IDeserializer<AzureMetadataV1>> _metadataDeserializer;
         private readonly Mock<IDeserializer<MetricDefaultsV1>> _defaultsDeserializer;
         private readonly Mock<IDeserializer<MetricDefinitionV1>> _metricsDeserializer;
+        private readonly Mock<IErrorReporter> _errorReporter = new Mock<IErrorReporter>();
         private readonly V1Deserializer _deserializer;
 
         public V1DeserializerTests()
@@ -39,7 +40,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Core
             var yamlNode = YamlUtils.CreateYamlNode("azureMetadata:");
 
             // Act
-            var exception = Assert.Throws<Exception>(() => _deserializer.Deserialize(yamlNode));
+            var exception = Assert.Throws<Exception>(() => _deserializer.Deserialize(yamlNode, _errorReporter.Object));
 
             // Assert
             Assert.Equal("No 'version' element was found in the metrics config", exception.Message);
@@ -52,7 +53,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Core
             var yamlNode = YamlUtils.CreateYamlNode("version: v1");
 
             // Act
-            var builder = _deserializer.Deserialize(yamlNode);
+            var builder = _deserializer.Deserialize(yamlNode, _errorReporter.Object);
 
             // Assert
             Assert.Equal("v1", builder.Version);
@@ -65,7 +66,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Core
             var yamlNode = YamlUtils.CreateYamlNode("version: v2");
 
             // Act
-            var exception = Assert.Throws<Exception>(() => _deserializer.Deserialize(yamlNode));
+            var exception = Assert.Throws<Exception>(() => _deserializer.Deserialize(yamlNode, _errorReporter.Object));
 
             // Assert
             Assert.Equal("A 'version' element with a value of 'v1' was expected but the value 'v2' was found", exception.Message);
@@ -81,10 +82,11 @@ azureMetadata:
   tenantId: 'abc-123'";
             var yamlNode = YamlUtils.CreateYamlNode(config);
             var azureMetadata = new AzureMetadataV1();
-            _metadataDeserializer.Setup(d => d.Deserialize(It.IsAny<YamlMappingNode>())).Returns(azureMetadata);
+            _metadataDeserializer.Setup(
+                d => d.Deserialize(It.IsAny<YamlMappingNode>(), It.IsAny<IErrorReporter>())).Returns(azureMetadata);
 
             // Act
-            var declaration = _deserializer.Deserialize(yamlNode);
+            var declaration = _deserializer.Deserialize(yamlNode, _errorReporter.Object);
 
             // Assert
             Assert.Same(azureMetadata, declaration.AzureMetadata);
@@ -96,10 +98,10 @@ azureMetadata:
             // Arrange
             var yamlNode = YamlUtils.CreateYamlNode("version: v1");
             _metadataDeserializer.Setup(
-                d => d.Deserialize(It.IsAny<YamlMappingNode>())).Returns(new AzureMetadataV1());
+                d => d.Deserialize(It.IsAny<YamlMappingNode>(), It.IsAny<IErrorReporter>())).Returns(new AzureMetadataV1());
 
             // Act
-            var declaration = _deserializer.Deserialize(yamlNode);
+            var declaration = _deserializer.Deserialize(yamlNode, _errorReporter.Object);
 
             // Assert
             Assert.Null(declaration.AzureMetadata);
@@ -116,10 +118,11 @@ metricDefaults:
     interval: '00:05:00'";
             var yamlNode = YamlUtils.CreateYamlNode(config);
             var metricDefaults = new MetricDefaultsV1();
-            _defaultsDeserializer.Setup(d => d.Deserialize(It.IsAny<YamlMappingNode>())).Returns(metricDefaults);
+            _defaultsDeserializer.Setup(
+                d => d.Deserialize(It.IsAny<YamlMappingNode>(), It.IsAny<IErrorReporter>())).Returns(metricDefaults);
 
             // Act
-            var declaration = _deserializer.Deserialize(yamlNode);
+            var declaration = _deserializer.Deserialize(yamlNode, _errorReporter.Object);
 
             // Assert
             Assert.Same(metricDefaults, declaration.MetricDefaults);
@@ -133,10 +136,10 @@ metricDefaults:
                 @"version: v1";
             var yamlNode = YamlUtils.CreateYamlNode(config);
             _defaultsDeserializer.Setup(
-                d => d.Deserialize(It.IsAny<YamlMappingNode>())).Returns(new MetricDefaultsV1());
+                d => d.Deserialize(It.IsAny<YamlMappingNode>(), It.IsAny<IErrorReporter>())).Returns(new MetricDefaultsV1());
 
             // Act
-            var declaration = _deserializer.Deserialize(yamlNode);
+            var declaration = _deserializer.Deserialize(yamlNode, _errorReporter.Object);
 
             // Assert
             Assert.Null(declaration.MetricDefaults);
@@ -152,10 +155,11 @@ metrics:
 - name: promitor_metrics_total";
             var yamlNode = YamlUtils.CreateYamlNode(config);
             var metrics = new List<MetricDefinitionV1>();
-            _metricsDeserializer.Setup(d => d.Deserialize(It.IsAny<YamlSequenceNode>())).Returns(metrics);
+            _metricsDeserializer.Setup(
+                d => d.Deserialize(It.IsAny<YamlSequenceNode>(), It.IsAny<IErrorReporter>())).Returns(metrics);
 
             // Act
-            var declaration = _deserializer.Deserialize(yamlNode);
+            var declaration = _deserializer.Deserialize(yamlNode, _errorReporter.Object);
 
             // Assert
             Assert.Same(metrics, declaration.Metrics);
@@ -169,10 +173,10 @@ metrics:
                 @"version: v1";
             var yamlNode = YamlUtils.CreateYamlNode(config);
             _metricsDeserializer.Setup(
-                d => d.Deserialize(It.IsAny<YamlSequenceNode>())).Returns(new List<MetricDefinitionV1>());
+                d => d.Deserialize(It.IsAny<YamlSequenceNode>(), It.IsAny<IErrorReporter>())).Returns(new List<MetricDefinitionV1>());
 
             // Act
-            var declaration = _deserializer.Deserialize(yamlNode);
+            var declaration = _deserializer.Deserialize(yamlNode, _errorReporter.Object);
 
             // Assert
             Assert.Null(declaration.Metrics);

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/StorageQueueDeserializerTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/StorageQueueDeserializerTests.cs
@@ -11,6 +11,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Providers
     public class StorageQueueDeserializerTests : ResourceDeserializerTest<StorageQueueDeserializer>
     {
         private readonly Mock<IDeserializer<SecretV1>> _secretDeserializer;
+        private readonly Mock<IErrorReporter> _errorReporter = new Mock<IErrorReporter>();
 
         private readonly StorageQueueDeserializer _deserializer;
 
@@ -71,10 +72,10 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Providers
             var sasTokenNode = (YamlMappingNode)node.Children["sasToken"];
 
             var secret = new SecretV1();
-            _secretDeserializer.Setup(d => d.Deserialize(sasTokenNode)).Returns(secret);
+            _secretDeserializer.Setup(d => d.Deserialize(sasTokenNode, _errorReporter.Object)).Returns(secret);
 
             // Act
-            var resource = (StorageQueueResourceV1)_deserializer.Deserialize(node);
+            var resource = (StorageQueueResourceV1)_deserializer.Deserialize(node, _errorReporter.Object);
 
             // Assert
             Assert.Same(secret, resource.SasToken);

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/V1SerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/V1SerializationTests.cs
@@ -27,6 +27,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1
         private readonly V1Deserializer _v1Deserializer;
         private readonly ConfigurationSerializer _configurationSerializer;
         private readonly MetricsDeclarationV1 _metricsDeclaration;
+        private readonly IErrorReporter _errorReporter = new ErrorReporter();
 
         public V1SerializationTests()
         {
@@ -130,7 +131,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1
             var yaml = _configurationSerializer.Serialize(_metricsDeclaration);
 
             // Act
-            var deserializedModel = _v1Deserializer.Deserialize(YamlUtils.CreateYamlNode(yaml));
+            var deserializedModel = _v1Deserializer.Deserialize(YamlUtils.CreateYamlNode(yaml), _errorReporter);
 
             // Assert
             Assert.NotNull(deserializedModel);

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/YamlAssert.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/YamlAssert.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Moq;
 using Promitor.Core.Scraping.Configuration.Serialization;
 using Xunit;
 using YamlDotNet.RepresentationModel;
@@ -19,12 +20,14 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1
         /// <param name="propertyAccessor">The property to check.</param>
         public static void PropertySet<TObject, TResult>(
             IDeserializer<TObject> deserializer, string yamlText, TResult expected, Func<TObject, TResult> propertyAccessor)
+            where TObject: new()
         {
             // Arrange
+            var errorReporter = new Mock<IErrorReporter>();
             var node = YamlUtils.CreateYamlNode(yamlText);
 
             // Act
-            var definition = deserializer.Deserialize(node);
+            var definition = deserializer.Deserialize(node, errorReporter.Object);
 
             // Assert
             Assert.Equal(expected, propertyAccessor(definition));
@@ -44,12 +47,14 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1
         public static void PropertySet<TObject, TBaseObject, TResult>(
             IDeserializer<TBaseObject> deserializer, string yamlText, TResult expected, Func<TObject, TResult> propertyAccessor)
             where TObject: TBaseObject
+            where TBaseObject: new()
         {
             // Arrange
+            var errorReporter = new Mock<IErrorReporter>();
             var node = YamlUtils.CreateYamlNode(yamlText);
 
             // Act
-            var definition = deserializer.Deserialize(node);
+            var definition = deserializer.Deserialize(node, errorReporter.Object);
 
             // Assert
             Assert.Equal(expected, propertyAccessor((TObject)definition));
@@ -68,12 +73,14 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1
         /// <param name="propertyAccessor">The property to check.</param>
         public static void PropertySet<TObject, TResult>(
             IDeserializer<TObject> deserializer, string yamlText, string yamlElement, TResult expected, Func<TObject, TResult> propertyAccessor)
+            where TObject: new()
         {
             // Arrange
+            var errorReporter = new Mock<IErrorReporter>();
             var node = YamlUtils.CreateYamlNode(yamlText).Children[yamlElement];
 
             // Act
-            var definition = deserializer.Deserialize((YamlMappingNode)node);
+            var definition = deserializer.Deserialize((YamlMappingNode)node, errorReporter.Object);
 
             // Assert
             Assert.Equal(expected, propertyAccessor(definition));
@@ -88,12 +95,14 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1
         /// <param name="propertyAccessor">The property to check.</param>
         public static void PropertyNull<TObject>(
             IDeserializer<TObject> deserializer, string yamlText, Func<TObject, object> propertyAccessor)
+            where TObject: new()
         {
             // Arrange
+            var errorReporter = new Mock<IErrorReporter>();
             var node = YamlUtils.CreateYamlNode(yamlText);
 
             // Act
-            var definition = deserializer.Deserialize(node);
+            var definition = deserializer.Deserialize(node, errorReporter.Object);
 
             // Assert
             Assert.Null(propertyAccessor(definition));
@@ -110,12 +119,14 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1
         public static void PropertyNull<TObject, TBaseObject>(
             IDeserializer<TBaseObject> deserializer, string yamlText, Func<TObject, object> propertyAccessor)
             where TObject: TBaseObject
+            where TBaseObject: new()
         {
             // Arrange
+            var errorReporter = new Mock<IErrorReporter>();
             var node = YamlUtils.CreateYamlNode(yamlText);
 
             // Act
-            var definition = deserializer.Deserialize(node);
+            var definition = deserializer.Deserialize(node, errorReporter.Object);
 
             // Assert
             Assert.Null(propertyAccessor((TObject)definition));
@@ -132,12 +143,14 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1
         /// <param name="yamlElement">The element to look for the property under.</param>
         public static void PropertyNull<TObject>(
             IDeserializer<TObject> deserializer, string yamlText, string yamlElement, Func<TObject, object> propertyAccessor)
+            where TObject: new()
         {
             // Arrange
+            var errorReporter = new Mock<IErrorReporter>();
             var node = YamlUtils.CreateYamlNode(yamlText).Children[yamlElement];
 
             // Act
-            var definition = deserializer.Deserialize((YamlMappingNode)node);
+            var definition = deserializer.Deserialize((YamlMappingNode)node, errorReporter.Object);
 
             // Assert
             Assert.Null(propertyAccessor(definition));


### PR DESCRIPTION
I've altered the way that the deserializers work and are defined so that they are simpler to create, but also so that we can record validation failures during the deserialization process. This allows us to provide much better validation messages than we can if we take the approach of validating based on the deserialized objects.

In this initial change I haven't gone ahead and updated all of the deserializers because I wanted the change to be kept small. I've also not actually hooked up the validation messages in any way - instead I've just provided a stub ErrorReporter object that doesn't actually do anything yet.

<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md -->

Fixes #
