### PR TITLE
Converted all of the resource type deserializers

### DIFF
--- a/src/Promitor.Core.Scraping/Configuration/Serialization/Deserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/Deserializer.cs
@@ -58,7 +58,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
         }
 
         /// <inheritdoc />
-        public List<TObject> Deserialize(YamlSequenceNode nodes, IErrorReporter errorReporter)
+        public IReadOnlyCollection<TObject> Deserialize(YamlSequenceNode nodes, IErrorReporter errorReporter)
         {
             Guard.NotNull(nodes, nameof(nodes));
 

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/IDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/IDeserializer.cs
@@ -21,7 +21,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
     /// An object that can deserialize a yaml node into an object.
     /// </summary>
     /// <typeparam name="TObject">The type of object that can be deserialized.</typeparam>
-    public interface IDeserializer<TObject> : IDeserializer where TObject: new()
+    public interface IDeserializer<out TObject> : IDeserializer where TObject: new()
     {
         /// <summary>
         /// Deserializes the specified node.
@@ -37,6 +37,6 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
         /// <param name="node">The node to deserialize.</param>
         /// <param name="errorReporter">Used to report deserialization errors.</param>
         /// <returns>The deserialized objects.</returns>
-        List<TObject> Deserialize(YamlSequenceNode node, IErrorReporter errorReporter);
+        IReadOnlyCollection<TObject> Deserialize(YamlSequenceNode node, IErrorReporter errorReporter);
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/MetricDefinitionDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/MetricDefinitionDeserializer.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Linq;
+using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Model;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
 using YamlDotNet.RepresentationModel;

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/V1Deserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/V1Deserializer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.Enum;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
@@ -73,7 +74,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
             return null;
         }
 
-        private List<MetricDefinitionV1> DeserializeMetrics(YamlMappingNode rootNode, IErrorReporter errorReporter)
+        private IReadOnlyCollection<MetricDefinitionV1> DeserializeMetrics(YamlMappingNode rootNode, IErrorReporter errorReporter)
         {
             if (rootNode.Children.TryGetValue("metrics", out var metricsNode))
             {

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/MetricDefinitionV1.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/MetricDefinitionV1.cs
@@ -42,6 +42,6 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Model
         /// <summary>
         /// The resources to be scraped.
         /// </summary>
-        public List<AzureResourceDefinitionV1> Resources { get; set; }
+        public IReadOnlyCollection<AzureResourceDefinitionV1> Resources { get; set; }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/MetricsDeclarationV1.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/MetricsDeclarationV1.cs
@@ -11,6 +11,6 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Model
         public string Version { get; set; } = SpecVersion.v1.ToString();
         public AzureMetadataV1 AzureMetadata { get; set; }
         public MetricDefaultsV1 MetricDefaults { get; set; }
-        public List<MetricDefinitionV1> Metrics { get; set; }
+        public IReadOnlyCollection<MetricDefinitionV1> Metrics { get; set; }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ApiManagementDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ApiManagementDeserializer.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
-using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
@@ -15,18 +14,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         /// <param name="logger">The logger.</param>
         public ApiManagementDeserializer(ILogger logger) : base(logger)
         {
-        }
-
-        protected override ApiManagementResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
-        {
-            var instanceName = node.GetString("instanceName");
-            var locationName = node.GetString("locationName");
-
-            return new ApiManagementResourceV1
-            {
-                InstanceName = instanceName,
-                LocationName = locationName
-            };
+            MapRequired(resource => resource.InstanceName);
+            MapOptional(resource => resource.LocationName);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/AppPlanDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/AppPlanDeserializer.cs
@@ -1,25 +1,13 @@
 ﻿using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
-using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
     public class AppPlanDeserializer : ResourceDeserializer<AppPlanResourceV1>
     {
-        private const string AppPlanNameTag = "appPlanName";
-
         public AppPlanDeserializer(ILogger<AppPlanDeserializer> logger) : base(logger)
         {
-        }
-
-        protected override AppPlanResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
-        {
-            var appPlanName = node.GetString(AppPlanNameTag);
-
-            return new AppPlanResourceV1
-            {
-               AppPlanName= appPlanName
-            };
+            MapRequired(resource => resource.AppPlanName);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/BlobStorageDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/BlobStorageDeserializer.cs
@@ -1,20 +1,13 @@
 ﻿using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
-using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
-    public class BlobStorageDeserializer : StorageAccountDeserializer
+    public class BlobStorageDeserializer : ResourceDeserializer<BlobStorageResourceV1>
     {
         public BlobStorageDeserializer(ILogger<BlobStorageDeserializer> logger) : base(logger)
         {
-        }
-
-        protected override StorageAccountResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
-        {
-            var storageAccountResource = base.DeserializeResource(node, errorReporter);
-
-            return new BlobStorageResourceV1(storageAccountResource);
+            MapRequired(resource => resource.AccountName);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ContainerInstanceDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ContainerInstanceDeserializer.cs
@@ -1,25 +1,13 @@
 ﻿using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
-using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
     public class ContainerInstanceDeserializer : ResourceDeserializer<ContainerInstanceResourceV1>
     {
-        private const string ContainerGroupTag = "containerGroup";
-
         public ContainerInstanceDeserializer(ILogger<ContainerInstanceDeserializer> logger) : base(logger)
         {
-        }
-
-        protected override ContainerInstanceResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
-        {
-            var containerGroup = node.GetString(ContainerGroupTag);
-
-            return new ContainerInstanceResourceV1
-            {
-                ContainerGroup = containerGroup
-            };
+            MapRequired(resource => resource.ContainerGroup);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ContainerRegistryDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ContainerRegistryDeserializer.cs
@@ -6,20 +6,9 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
     public class ContainerRegistryDeserializer : ResourceDeserializer<ContainerRegistryResourceV1>
     {
-        private const string RegistryNameTag = "registryName";
-
         public ContainerRegistryDeserializer(ILogger<ContainerRegistryDeserializer> logger) : base(logger)
         {
-        }
-
-        protected override ContainerRegistryResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
-        {
-            var registryName = node.GetString(RegistryNameTag);
-
-            return new ContainerRegistryResourceV1
-            {
-                RegistryName = registryName
-            };
+            MapRequired(resource => resource.RegistryName);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/CosmosDbDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/CosmosDbDeserializer.cs
@@ -1,25 +1,13 @@
 ﻿using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
-using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
     public class CosmosDbDeserializer : ResourceDeserializer<CosmosDbResourceV1>
     {
-        private const string DatabaseNameTag = "dbName";
-
         public CosmosDbDeserializer(ILogger<CosmosDbDeserializer> logger) : base(logger)
         {
-        }
-
-        protected override CosmosDbResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
-        {
-            var databaseName = node.GetString(DatabaseNameTag);
-
-            return new CosmosDbResourceV1
-            {
-                DbName = databaseName
-            };
+            MapRequired(resource => resource.DbName);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/FileStorageDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/FileStorageDeserializer.cs
@@ -1,20 +1,13 @@
 ﻿using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
-using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
-    public class FileStorageDeserializer : StorageAccountDeserializer
+    public class FileStorageDeserializer : ResourceDeserializer<FileStorageResourceV1>
     {
         public FileStorageDeserializer(ILogger<FileStorageDeserializer> logger) : base(logger)
         {
-        }
-
-        protected override StorageAccountResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
-        {
-            var storageAccountResource = base.DeserializeResource(node, errorReporter);
-
-            return new FileStorageResourceV1(storageAccountResource);
+            MapRequired(resource => resource.AccountName);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/FunctionAppDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/FunctionAppDeserializer.cs
@@ -1,28 +1,14 @@
 ﻿using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
-using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
     public class FunctionAppDeserializer : ResourceDeserializer<FunctionAppResourceV1>
     {
-        private const string FunctionAppNameTag = "functionAppName";
-        private const string SlotNameTag = "slotName";
-
         public FunctionAppDeserializer(ILogger<FunctionAppDeserializer> logger) : base(logger)
         {
-        }
-
-        protected override FunctionAppResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
-        {
-            var functionAppName = node.GetString(FunctionAppNameTag);
-            var slotName = node.GetString(SlotNameTag);
-
-            return new FunctionAppResourceV1
-            {
-                FunctionAppName = functionAppName,
-                SlotName = slotName
-            };
+            MapRequired(resource => resource.FunctionAppName);
+            MapOptional(resource => resource.SlotName);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/GenericResourceDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/GenericResourceDeserializer.cs
@@ -1,28 +1,14 @@
 ﻿using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
-using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
     public class GenericResourceDeserializer : ResourceDeserializer<GenericResourceV1>
     {
-        private const string FilterTag = "filter";
-        private const string ResourceUriTag = "resourceUri";
-
         public GenericResourceDeserializer(ILogger<GenericResourceDeserializer> logger) : base(logger)
         {
-        }
-
-        protected override GenericResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
-        {
-            var filter = node.GetString(FilterTag);
-            var resourceUri = node.GetString(ResourceUriTag);
-
-            return new GenericResourceV1
-            {
-                Filter = filter,
-                ResourceUri = resourceUri
-            };
+            MapRequired(resource => resource.ResourceUri);
+            MapOptional(resource => resource.Filter);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/NetworkInterfaceDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/NetworkInterfaceDeserializer.cs
@@ -1,25 +1,13 @@
 ﻿using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
-using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
     public class NetworkInterfaceDeserializer : ResourceDeserializer<NetworkInterfaceResourceV1>
     {
-        private const string NetworkInterfaceNameTag = "networkInterfaceName";
-
         public NetworkInterfaceDeserializer(ILogger<NetworkInterfaceDeserializer> logger) : base(logger)
         {
-        }
-
-        protected override NetworkInterfaceResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
-        {
-            var networkInterfaceName = node.GetString(NetworkInterfaceNameTag);
-
-            return new NetworkInterfaceResourceV1
-            {
-                NetworkInterfaceName = networkInterfaceName
-            };
+            MapRequired(resource => resource.NetworkInterfaceName);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/PostgreSqlDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/PostgreSqlDeserializer.cs
@@ -1,25 +1,13 @@
 ﻿using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
-using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
     public class PostgreSqlDeserializer : ResourceDeserializer<PostgreSqlResourceV1>
     {
-        private const string ServerNameTag = "serverName";
-
         public PostgreSqlDeserializer(ILogger<PostgreSqlDeserializer> logger) : base(logger)
         {
-        }
-
-        protected override PostgreSqlResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
-        {
-            var serverName = node.GetString(ServerNameTag);
-
-            return new PostgreSqlResourceV1
-            {
-                ServerName = serverName
-            };
+            MapRequired(resource => resource.ServerName);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/RedisCacheDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/RedisCacheDeserializer.cs
@@ -1,25 +1,13 @@
 ﻿using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
-using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
     public class RedisCacheDeserializer : ResourceDeserializer<RedisCacheResourceV1>
     {
-        private const string CacheNameTag = "cacheName";
-
         public RedisCacheDeserializer(ILogger<RedisCacheDeserializer> logger) : base(logger)
         {
-        }
-
-        protected override RedisCacheResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
-        {
-            var cacheName = node.GetString(CacheNameTag);
-
-            return new RedisCacheResourceV1
-            {
-                CacheName = cacheName
-            };
+            MapRequired(resource => resource.CacheName);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ResourceDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ResourceDeserializer.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
-using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
@@ -8,31 +7,12 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     ///     A base class for azure resource deserializers that makes sure that any shared
     ///     properties are deserialized correctly for all resources.
     /// </summary>
-    public abstract class ResourceDeserializer<TResourceDefinition> : Deserializer<AzureResourceDefinitionV1>
-        where TResourceDefinition : AzureResourceDefinitionV1
+    public abstract class ResourceDeserializer<TResourceDefinition> : Deserializer<TResourceDefinition>
+        where TResourceDefinition : AzureResourceDefinitionV1, new()
     {
-        private const string ResourceGroupNameTag = "resourceGroupName";
-
         protected ResourceDeserializer(ILogger logger) : base(logger)
         {
+            MapOptional(resource => resource.ResourceGroupName);
         }
-
-        public override AzureResourceDefinitionV1 Deserialize(YamlMappingNode node, IErrorReporter errorReporter)
-        {
-            var resource = DeserializeResource(node, errorReporter);
-
-            resource.ResourceGroupName = node.GetString(ResourceGroupNameTag);
-
-            return resource;
-        }
-
-        /// <summary>
-        ///     Implement on subclasses to return the correct type of <see cref="AzureResourceDefinitionV1" />
-        ///     object with all its custom properties populated.
-        /// </summary>
-        /// <param name="node">The yaml node.</param>
-        /// <param name="errorReporter">Used to report errors with the deserialization process.</param>
-        /// <returns>The deserialized object.</returns>
-        protected abstract TResourceDefinition DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter);
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ServiceBusQueueDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ServiceBusQueueDeserializer.cs
@@ -1,28 +1,14 @@
 ﻿using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
-using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
     public class ServiceBusQueueDeserializer : ResourceDeserializer<ServiceBusQueueResourceV1>
     {
-        private const string QueueNameTag = "queueName";
-        private const string NamespaceTag = "namespace";
-
         public ServiceBusQueueDeserializer(ILogger<ServiceBusQueueDeserializer> logger) : base(logger)
         {
-        }
-
-        protected override ServiceBusQueueResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
-        {
-            var queueName = node.GetString(QueueNameTag);
-            var @namespace = node.GetString(NamespaceTag);
-
-            return new ServiceBusQueueResourceV1
-            {
-                QueueName = queueName,
-                Namespace = @namespace
-            };
+            MapRequired(resource => resource.QueueName);
+            MapRequired(resource => resource.Namespace);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/SqlDatabaseDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/SqlDatabaseDeserializer.cs
@@ -1,13 +1,12 @@
 using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
-using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
     /// <summary>
     /// Used to deserialize a <see cref="SqlDatabaseResourceV1" /> resource.
     /// </summary>
-    public class SqlDatabaseDeserializer : SqlServerDeserializer
+    public class SqlDatabaseDeserializer : ResourceDeserializer<SqlDatabaseResourceV1>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SqlDatabaseDeserializer" /> class.
@@ -15,16 +14,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         /// <param name="logger">The logger.</param>
         public SqlDatabaseDeserializer(ILogger logger) : base(logger)
         {
-        }
-
-        protected override SqlServerResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
-        {
-            var sqlServerResource = base.DeserializeResource(node, errorReporter);
-
-            return new SqlDatabaseResourceV1(sqlServerResource)
-            {
-                DatabaseName = node.GetString("databaseName")
-            };
+            MapRequired(resource => resource.ServerName);
+            MapRequired(resource => resource.DatabaseName);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/SqlManagedInstanceDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/SqlManagedInstanceDeserializer.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
-using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
@@ -15,16 +14,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         /// <param name="logger">The logger.</param>
         public SqlManagedInstanceDeserializer(ILogger logger) : base(logger)
         {
-        }
-
-        protected override SqlManagedInstanceResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
-        {
-            var instanceName = node.GetString("instanceName");
-
-            return new SqlManagedInstanceResourceV1
-            {
-                InstanceName = instanceName
-            };
+            MapRequired(resource => resource.InstanceName);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/SqlServerDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/SqlServerDeserializer.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
-using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
@@ -15,16 +14,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         /// <param name="logger">The logger.</param>
         public SqlServerDeserializer(ILogger logger) : base(logger)
         {
-        }
-
-        protected override SqlServerResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
-        {
-            var serverName = node.GetString("serverName");
-
-            return new SqlServerResourceV1
-            {
-                ServerName = serverName
-            };
+            MapRequired(resource => resource.ServerName);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/StorageAccountDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/StorageAccountDeserializer.cs
@@ -1,25 +1,13 @@
 ﻿using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
-using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
     public class StorageAccountDeserializer : ResourceDeserializer<StorageAccountResourceV1>
     {
-        private const string AccountNameTag = "accountName";
-
         public StorageAccountDeserializer(ILogger<StorageAccountDeserializer> logger) : base(logger)
         {
-        }
-
-        protected override StorageAccountResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
-        {
-            var accountName = node.GetString(AccountNameTag);
-
-            return new StorageAccountResourceV1
-            {
-                AccountName = accountName
-            };
+            MapRequired(resource => resource.AccountName);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/StorageQueueDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/StorageQueueDeserializer.cs
@@ -1,36 +1,16 @@
 ﻿using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
-using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
-    public class StorageQueueDeserializer : StorageAccountDeserializer
+    public class StorageQueueDeserializer : ResourceDeserializer<StorageQueueResourceV1>
     {
-        private const string QueueNameTag = "queueName";
-        private const string SasTokenTag = "sasToken";
-
-        private readonly IDeserializer<SecretV1> _secretDeserializer;
-
         public StorageQueueDeserializer(IDeserializer<SecretV1> secretDeserializer, ILogger<StorageQueueDeserializer> logger) : base(logger)
         {
-            _secretDeserializer = secretDeserializer;
-        }
-
-        protected override StorageAccountResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
-        {
-            var storageAccountResource = base.DeserializeResource(node, errorReporter);
-
-            var queueName = node.GetString(QueueNameTag);
-            var sasToken = node.DeserializeChild(SasTokenTag, _secretDeserializer, errorReporter);
-
-            var storageQueueResource = new StorageQueueResourceV1(storageAccountResource)
-            {
-                QueueName = queueName,
-                SasToken = sasToken
-            };
-
-            return storageQueueResource;
+            MapRequired(resource => resource.AccountName);
+            MapRequired(resource => resource.QueueName);
+            MapRequired(resource => resource.SasToken, secretDeserializer);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/VirtualMachineDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/VirtualMachineDeserializer.cs
@@ -1,25 +1,13 @@
 ﻿using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
-using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
     public class VirtualMachineDeserializer : ResourceDeserializer<VirtualMachineResourceV1>
     {
-        private const string VirtualMachineNameTag = "virtualMachineName";
-
         public VirtualMachineDeserializer(ILogger<VirtualMachineDeserializer> logger) : base(logger)
         {
-        }
-
-        protected override VirtualMachineResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
-        {
-            var virtualMachineName = node.GetString(VirtualMachineNameTag);
-
-            return new VirtualMachineResourceV1
-            {
-                VirtualMachineName = virtualMachineName
-            };
+            MapRequired(resource => resource.VirtualMachineName);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/VirtualMachineScaleSetDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/VirtualMachineScaleSetDeserializer.cs
@@ -1,25 +1,13 @@
 ﻿using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
-using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
     public class VirtualMachineScaleSetDeserializer : ResourceDeserializer<VirtualMachineScaleSetResourceV1>
     {
-        private const string ScaleSetNameTag = "scaleSetName";
-
         public VirtualMachineScaleSetDeserializer(ILogger<VirtualMachineScaleSetDeserializer> logger) : base(logger)
         {
-        }
-
-        protected override VirtualMachineScaleSetResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
-        {
-            var scaleSetName = node.GetString(ScaleSetNameTag);
-
-            return new VirtualMachineScaleSetResourceV1
-            {
-                ScaleSetName = scaleSetName
-            };
+            MapRequired(resource => resource.ScaleSetName);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/WebAppDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/WebAppDeserializer.cs
@@ -1,28 +1,14 @@
 ﻿using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
-using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
     public class WebAppDeserializer : ResourceDeserializer<WebAppResourceV1>
     {
-        private const string WebAppNameTag = "webAppName";
-        private const string SlotNameTag = "slotName";
-
         public WebAppDeserializer(ILogger<WebAppDeserializer> logger) : base(logger)
         {
-        }
-
-        protected override WebAppResourceV1 DeserializeResource(YamlMappingNode node, IErrorReporter errorReporter)
-        {
-            var webAppName = node.GetString(WebAppNameTag);
-            var slotName = node.GetString(SlotNameTag);
-
-            return new WebAppResourceV1
-            {
-                WebAppName = webAppName,
-                SlotName = slotName,
-            };
+            MapRequired(resource => resource.WebAppName);
+            MapOptional(resource => resource.SlotName);
         }
     }
 }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Core/MetricDefinitionDeserializerTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Core/MetricDefinitionDeserializerTests.cs
@@ -260,15 +260,20 @@ resources:
             _resourceDeserializerFactory.Setup(
                 f => f.GetDeserializerFor(ResourceType.Generic)).Returns(resourceDeserializer.Object);
 
-            var resources = new List<AzureResourceDefinitionV1>();
+            var resources = new List<AzureResourceDefinitionV1>
+            {
+                new AzureResourceDefinitionV1 { ResourceGroupName = "promitor-group" }
+            };
             resourceDeserializer.Setup(
-                d => d.Deserialize((YamlSequenceNode)node.Children["resources"], _errorReporter.Object)).Returns(resources);
+                d => d.Deserialize((YamlSequenceNode)node.Children["resources"], _errorReporter.Object))
+                .Returns(resources);
 
             // Act
             var definition = _deserializer.Deserialize(node, _errorReporter.Object);
 
             // Assert
-            Assert.Same(resources, definition.Resources);
+            Assert.Collection(definition.Resources,
+                resource => Assert.Equal("promitor-group", resource.ResourceGroupName));
         }
 
         [Fact]

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Core/V1DeserializerTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Core/V1DeserializerTests.cs
@@ -154,7 +154,7 @@ metricDefaults:
 metrics:
 - name: promitor_metrics_total";
             var yamlNode = YamlUtils.CreateYamlNode(config);
-            var metrics = new List<MetricDefinitionV1>();
+            var metrics = new List<MetricDefinitionV1> { new MetricDefinitionV1 { Name = "test_metric" } };
             _metricsDeserializer.Setup(
                 d => d.Deserialize(It.IsAny<YamlSequenceNode>(), It.IsAny<IErrorReporter>())).Returns(metrics);
 
@@ -162,7 +162,7 @@ metrics:
             var declaration = _deserializer.Deserialize(yamlNode, _errorReporter.Object);
 
             // Assert
-            Assert.Same(metrics, declaration.Metrics);
+            Assert.Collection(declaration.Metrics, metric => Assert.Equal("test_metric", metric.Name));
         }
 
         [Fact]

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/BlobStorageDeserializerTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/BlobStorageDeserializerTests.cs
@@ -8,7 +8,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Providers
 {
     public class BlobStorageDeserializerTests : ResourceDeserializerTest<BlobStorageDeserializer>
     {
-        private readonly StorageAccountDeserializer _deserializer;
+        private readonly BlobStorageDeserializer _deserializer;
 
         public BlobStorageDeserializerTests()
         {
@@ -37,7 +37,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Providers
 
         protected override IDeserializer<AzureResourceDefinitionV1> CreateDeserializer()
         {
-            return new StorageAccountDeserializer(Logger);
+            return new BlobStorageDeserializer(Logger);
         }
     }
 }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/ContainerInstanceDeserializerTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/ContainerInstanceDeserializerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Moq;
 using Promitor.Core.Scraping.Configuration.Serialization;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
@@ -39,6 +40,20 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Providers
                 _deserializer,
                 "resourceGroupName: promitor-resource-group",
                 c => c.ContainerGroup);
+        }
+
+        [Fact]
+        public void Deserialize_ContainerGroupNotSupplied_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("resourceGroupName: promitor-resource-group");
+            var errorReporter = new Mock<IErrorReporter>();
+
+            // Act
+            _deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            errorReporter.Verify(r => r.ReportError(node, It.Is<string>(s => s.Contains("containerGroup"))));
         }
     }
 }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/ContainerRegistryDeserializerTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/ContainerRegistryDeserializerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Moq;
 using Promitor.Core.Scraping.Configuration.Serialization;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
@@ -34,6 +35,20 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Providers
                 _deserializer,
                 "resourceGroupName: promitor-group",
                 c => c.RegistryName);
+        }
+
+        [Fact]
+        public void Deserialize_RegistryNameNotSupplied_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("resourceGroupName: promitor-resource-group");
+            var errorReporter = new Mock<IErrorReporter>();
+
+            // Act
+            _deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            errorReporter.Verify(r => r.ReportError(node, It.Is<string>(s => s.Contains("registryName"))));
         }
 
         protected override IDeserializer<AzureResourceDefinitionV1> CreateDeserializer()

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/CosmosDbDeserializerTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/CosmosDbDeserializerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Moq;
 using Promitor.Core.Scraping.Configuration.Serialization;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
@@ -34,6 +35,20 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Providers
                 _deserializer,
                 "resourceGroupName: promitor-group",
                 c => c.DbName);
+        }
+
+        [Fact]
+        public void Deserialize_DbNameNotSupplied_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("resourceGroupName: promitor-resource-group");
+            var errorReporter = new Mock<IErrorReporter>();
+
+            // Act
+            _deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            errorReporter.Verify(r => r.ReportError(node, It.Is<string>(s => s.Contains("dbName"))));
         }
 
         protected override IDeserializer<AzureResourceDefinitionV1> CreateDeserializer()

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/FileStorageDeserializerTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/FileStorageDeserializerTests.cs
@@ -37,7 +37,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Providers
 
         protected override IDeserializer<AzureResourceDefinitionV1> CreateDeserializer()
         {
-            return new StorageAccountDeserializer(Logger);
+            return new FileStorageDeserializer(Logger);
         }
     }
 }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/GenericResourceDeserializerTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/GenericResourceDeserializerTests.cs
@@ -1,4 +1,5 @@
-﻿using Promitor.Core.Scraping.Configuration.Serialization;
+﻿using Moq;
+using Promitor.Core.Scraping.Configuration.Serialization;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Providers;
@@ -51,6 +52,20 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Providers
                 _deserializer,
                 "resourceGroupName: promitor-group",
                 r => r.ResourceUri);
+        }
+
+        [Fact]
+        public void Deserialize_ResourceUriNotSupplied_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("resourceGroupName: promitor-resource-group");
+            var errorReporter = new Mock<IErrorReporter>();
+
+            // Act
+            _deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            errorReporter.Verify(r => r.ReportError(node, It.Is<string>(s => s.Contains("resourceUri"))));
         }
 
         protected override IDeserializer<AzureResourceDefinitionV1> CreateDeserializer()

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/NetworkInterfaceDeserializerTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/NetworkInterfaceDeserializerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Moq;
 using Promitor.Core.Scraping.Configuration.Serialization;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
@@ -34,6 +35,20 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Providers
                 _deserializer,
                 "resourceGroupName: promitor-group",
                 r => r.NetworkInterfaceName);
+        }
+
+        [Fact]
+        public void Deserialize_NetworkInterfaceNameNotSupplied_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("resourceGroupName: promitor-resource-group");
+            var errorReporter = new Mock<IErrorReporter>();
+
+            // Act
+            _deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            errorReporter.Verify(r => r.ReportError(node, It.Is<string>(s => s.Contains("networkInterfaceName"))));
         }
 
         protected override IDeserializer<AzureResourceDefinitionV1> CreateDeserializer()

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/PostgreSqlDeserializerTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/PostgreSqlDeserializerTests.cs
@@ -1,4 +1,5 @@
-﻿using Promitor.Core.Scraping.Configuration.Serialization;
+﻿using Moq;
+using Promitor.Core.Scraping.Configuration.Serialization;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Providers;
@@ -32,6 +33,20 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Providers
                 _deserializer,
                 "resourceGroupName: promitor-group",
                 r => r.ServerName);
+        }
+
+        [Fact]
+        public void Deserialize_ServerNameNotSupplied_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("resourceGroupName: promitor-resource-group");
+            var errorReporter = new Mock<IErrorReporter>();
+
+            // Act
+            _deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            errorReporter.Verify(r => r.ReportError(node, It.Is<string>(s => s.Contains("serverName"))));
         }
 
         protected override IDeserializer<AzureResourceDefinitionV1> CreateDeserializer()

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/RedisCacheDeserializerTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/RedisCacheDeserializerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Moq;
 using Promitor.Core.Scraping.Configuration.Serialization;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
@@ -34,6 +35,20 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Providers
                 _deserializer,
                 "resourceGroupName: promitor-group",
                 r => r.CacheName);
+        }
+
+        [Fact]
+        public void Deserialize_CacheNameNotSupplied_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("resourceGroupName: promitor-resource-group");
+            var errorReporter = new Mock<IErrorReporter>();
+
+            // Act
+            _deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            errorReporter.Verify(r => r.ReportError(node, It.Is<string>(s => s.Contains("cacheName"))));
         }
 
         protected override IDeserializer<AzureResourceDefinitionV1> CreateDeserializer()

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/SqlDatabaseDeserializerTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/SqlDatabaseDeserializerTests.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 using Promitor.Core.Scraping.Configuration.Serialization;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
@@ -11,12 +12,8 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Providers
     [Category("Unit")]
     public class SqlDatabaseDeserializerTests : ResourceDeserializerTest<SqlDatabaseDeserializer>
     {
-        private readonly SqlDatabaseDeserializer _deserializer;
-
-        public SqlDatabaseDeserializerTests()
-        {
-            _deserializer = new SqlDatabaseDeserializer(NullLogger.Instance);
-        }
+        private readonly SqlDatabaseDeserializer _deserializer = new SqlDatabaseDeserializer(NullLogger.Instance);
+        private readonly Mock<IErrorReporter> _errorReporter = new Mock<IErrorReporter>();
 
         [Fact]
         public void Deserialize_ServerNameSupplied_SetsServerName()
@@ -38,6 +35,19 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Providers
         }
 
         [Fact]
+        public void Deserialize_ServerNameNotSupplied_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("resourceGroupName: promitor-resource-group");
+
+            // Act
+            _deserializer.Deserialize(node, _errorReporter.Object);
+
+            // Assert
+            _errorReporter.Verify(r => r.ReportError(node, It.Is<string>(s => s.Contains("serverName"))));
+        }
+
+        [Fact]
         public void Deserialize_DatabaseNameSupplied_SetsDatabaseName()
         {
             YamlAssert.PropertySet<SqlDatabaseResourceV1, AzureResourceDefinitionV1, string>(
@@ -54,6 +64,19 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Providers
                 _deserializer,
                 "resourceGroupName: promitor-group",
                 c => c.DatabaseName);
+        }
+
+        [Fact]
+        public void Deserialize_DatabaseNameNotSupplied_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("resourceGroupName: promitor-resource-group");
+
+            // Act
+            _deserializer.Deserialize(node, _errorReporter.Object);
+
+            // Assert
+            _errorReporter.Verify(r => r.ReportError(node, It.Is<string>(s => s.Contains("databaseName"))));
         }
 
         protected override IDeserializer<AzureResourceDefinitionV1> CreateDeserializer()

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/StorageQueueDeserializerTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/StorageQueueDeserializerTests.cs
@@ -43,6 +43,19 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Providers
         }
 
         [Fact]
+        public void Deserialize_AccountNameNotSupplied_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("resourceGroupName: promitor-resource-group");
+
+            // Act
+            _deserializer.Deserialize(node, _errorReporter.Object);
+
+            // Assert
+            _errorReporter.Verify(r => r.ReportError(node, It.Is<string>(s => s.Contains("accountName"))));
+        }
+
+        [Fact]
         public void Deserialize_QueueNameSupplied_SetsQueueName()
         {
             YamlAssert.PropertySet<StorageQueueResourceV1, AzureResourceDefinitionV1, string>(
@@ -62,6 +75,19 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Providers
         }
 
         [Fact]
+        public void Deserialize_QueueNameNotSupplied_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("resourceGroupName: promitor-group");
+
+            // Act
+            _deserializer.Deserialize(node, _errorReporter.Object);
+
+            // Assert
+            _errorReporter.Verify(r => r.ReportError(node, It.Is<string>(s => s.Contains("queueName"))));
+        }
+
+        [Fact]
         public void Deserialize_SasTokenSupplied_UsesDeserializer()
         {
             // Arrange
@@ -72,7 +98,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Providers
             var sasTokenNode = (YamlMappingNode)node.Children["sasToken"];
 
             var secret = new SecretV1();
-            _secretDeserializer.Setup(d => d.Deserialize(sasTokenNode, _errorReporter.Object)).Returns(secret);
+            _secretDeserializer.Setup(d => d.DeserializeObject(sasTokenNode, _errorReporter.Object)).Returns(secret);
 
             // Act
             var resource = (StorageQueueResourceV1)_deserializer.Deserialize(node, _errorReporter.Object);
@@ -88,6 +114,19 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Providers
                 _deserializer,
                 "resourceGroupName: promitor-group",
                 r => r.SasToken);
+        }
+
+        [Fact]
+        public void Deserialize_SasTokenNotSupplied_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("resourceGroupName: promitor-group");
+
+            // Act
+            _deserializer.Deserialize(node, _errorReporter.Object);
+
+            // Assert
+            _errorReporter.Verify(r => r.ReportError(node, It.Is<string>(s => s.Contains("sasToken"))));
         }
 
         protected override IDeserializer<AzureResourceDefinitionV1> CreateDeserializer()

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/VirtualMachineDeserializerTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/VirtualMachineDeserializerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Moq;
 using Promitor.Core.Scraping.Configuration.Serialization;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
@@ -34,6 +35,20 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Providers
                 _deserializer,
                 "resourceGroupName: promitor-group",
                 r => r.VirtualMachineName);
+        }
+
+        [Fact]
+        public void Deserialize_VirtualMachineNameNotSupplied_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("resourceGroupName: promitor-group");
+            var errorReporter = new Mock<IErrorReporter>();
+
+            // Act
+            _deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            errorReporter.Verify(r => r.ReportError(node, It.Is<string>(s => s.Contains("virtualMachineName"))));
         }
 
         protected override IDeserializer<AzureResourceDefinitionV1> CreateDeserializer()


### PR DESCRIPTION
In order to do this I had to alter the type parameter in `IDeserializer<TObject>` to be covariant so that I could define the resource deserializers as their specific type (for example `IDeserializer<ContainerInstanceResourceV1>`), but still allow them to be returned as an `IDeserializer<AzureResourceDefinitionV1>` from the resource deserializer factory.

I also ended up altering a few of the newer deserializers that are using inheritance (for example, SqlServer / SqlDatabase deserializers) to inherit directly from `ResourceDeserializer<TResource>` again. The reason I did this is that the `Deserializer` class needs to know the specific type of object to construct, and I decided that the extra complication of adding more generics to get it to work wasn't worth the hassle to save one or two lines of code.

<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md -->

Fixes #
