### PR TITLE
Hook up validation to Promitor

### DIFF
--- a/src/Promitor.Core.Scraping/Configuration/Providers/Interfaces/IMetricsDeclarationProvider.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Providers/Interfaces/IMetricsDeclarationProvider.cs
@@ -1,4 +1,5 @@
 ﻿using Promitor.Core.Scraping.Configuration.Model;
+using Promitor.Core.Scraping.Configuration.Serialization;
 
 namespace Promitor.Core.Scraping.Configuration.Providers.Interfaces
 {
@@ -9,7 +10,8 @@ namespace Promitor.Core.Scraping.Configuration.Providers.Interfaces
         /// </summary>
         /// <param name="applyDefaults"><c>true</c> if the provider should apply default values from top-level 
         /// configuration elements to metrics where those values aren't specified. <c>false</c> otherwise</param>
-        MetricsDeclaration Get(bool applyDefaults = false);
+        /// <param name="errorReporter">Used to report errors during the deserialization process.</param>
+        MetricsDeclaration Get(bool applyDefaults = false, IErrorReporter errorReporter = null);
 
         /// <summary>
         ///     Gets the serialized metrics declaration

--- a/src/Promitor.Core.Scraping/Configuration/Providers/MetricsDeclarationProvider.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Providers/MetricsDeclarationProvider.cs
@@ -19,11 +19,12 @@ namespace Promitor.Core.Scraping.Configuration.Providers
             _configuration = configuration;
         }
 
-        public virtual MetricsDeclaration Get(bool applyDefaults = false)
+        public virtual MetricsDeclaration Get(bool applyDefaults = false, IErrorReporter errorReporter = null)
         {
             var rawMetricsDeclaration = ReadRawDeclaration();
+            errorReporter ??= new ErrorReporter();
 
-            var config = _configurationSerializer.Deserialize(rawMetricsDeclaration);
+            var config = _configurationSerializer.Deserialize(rawMetricsDeclaration, errorReporter);
 
             if (applyDefaults)
             {

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/ConfigurationSerializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/ConfigurationSerializer.cs
@@ -26,9 +26,10 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
             _v1Deserializer = v1Deserializer;
         }
 
-        public MetricsDeclaration Deserialize(string rawMetricsDeclaration)
+        public MetricsDeclaration Deserialize(string rawMetricsDeclaration, IErrorReporter errorReporter)
         {
             Guard.NotNullOrWhitespace(rawMetricsDeclaration, nameof(rawMetricsDeclaration));
+            Guard.NotNull(errorReporter, nameof(errorReporter));
 
             var input = new StringReader(rawMetricsDeclaration);
             try
@@ -36,7 +37,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
                 var metricsDeclarationYamlStream = new YamlStream();
                 metricsDeclarationYamlStream.Load(input);
 
-                var metricsDeclaration = InterpretYamlStream(metricsDeclarationYamlStream);
+                var metricsDeclaration = InterpretYamlStream(metricsDeclarationYamlStream, errorReporter);
 
                 return metricsDeclaration;
             }
@@ -46,7 +47,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
             }
         }
 
-        private MetricsDeclaration InterpretYamlStream(YamlStream metricsDeclarationYamlStream)
+        private MetricsDeclaration InterpretYamlStream(YamlStream metricsDeclarationYamlStream, IErrorReporter errorReporter)
         {
             var document = metricsDeclarationYamlStream.Documents.First();
             var rootNode = (YamlMappingNode)document.RootNode;
@@ -57,7 +58,6 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
             switch (specVersion)
             {
                 case SpecVersion.v1:
-                    var errorReporter = new ErrorReporter();
                     var v1Config = _v1Deserializer.Deserialize(rootNode, errorReporter);
 
                     return _mapper.Map<MetricsDeclaration>(v1Config);

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/DeserializationContext.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/DeserializationContext.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Promitor.Core.Scraping.Configuration.Serialization
+{
+    /// <summary>
+    /// Contains the information needed to deserialize a node.
+    /// </summary>
+    public class DeserializationContext<TObject>
+    {
+        private readonly ISet<string> _ignoredFields;
+        private readonly Dictionary<string, FieldDeserializationContext<TObject>> _fields;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeserializationContext{TObject}"/> type.
+        /// </summary>
+        /// <param name="ignoredFields">The fields that should be ignored.</param>
+        /// <param name="fields">The fields that can be deserialized.</param>
+        public DeserializationContext(ISet<string> ignoredFields, IReadOnlyCollection<FieldDeserializationInfo> fields)
+        {
+            _ignoredFields = ignoredFields;
+            _fields = fields.ToDictionary(
+                fieldInfo => fieldInfo.YamlFieldName, fieldInfo => new FieldDeserializationContext<TObject>(fieldInfo));
+        }
+
+        /// <summary>
+        /// The fields that have not been set during deserialization.
+        /// </summary>
+        public IReadOnlyCollection<FieldDeserializationContext<TObject>> UnsetFields
+        {
+            get
+            {
+                return _fields
+                    .Where(f => !f.Value.HasBeenSet)
+                    .Select(f => f.Value)
+                    .ToList();
+            }
+        }
+
+        /// <summary>
+        /// Returns whether the specified field is ignored.
+        /// </summary>
+        /// <param name="fieldName">The field name.</param>
+        /// <returns>true if the field is ignored, false otherwise.</returns>
+        public bool IsIgnored(string fieldName)
+        {
+            return _ignoredFields.Contains(fieldName);
+        }
+
+        /// <summary>
+        /// Tries to find the specified field.
+        /// </summary>
+        /// <param name="fieldName">The field name.</param>
+        /// <param name="field">Set to the field if found, otherwise null.</param>
+        /// <returns>true if the field was found, false otherwise.</returns>
+        public bool TryGetField(string fieldName, out FieldDeserializationContext<TObject> field)
+        {
+            return _fields.TryGetValue(fieldName, out field);
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/DeserializationMessage.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/DeserializationMessage.cs
@@ -1,0 +1,45 @@
+using YamlDotNet.RepresentationModel;
+
+namespace Promitor.Core.Scraping.Configuration.Serialization
+{
+    /// <summary>
+    /// Represents a message reported during the deserialization process.
+    /// </summary>
+    public class DeserializationMessage
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeserializationMessage"/> type.
+        /// </summary>
+        /// <param name="messageType">The type of message reported.</param>
+        /// <param name="node">The node the message is associated with.</param>
+        /// <param name="message">The message.</param>
+        public DeserializationMessage(MessageType messageType, YamlNode node, string message)
+        {
+            MessageType = messageType;
+            Node = node;
+            Message = message;
+        }
+
+        /// <summary>
+        /// Gets the type of message.
+        /// </summary>
+        public MessageType MessageType { get; }
+
+        /// <summary>
+        /// Gets the node the message has been reported against.
+        /// </summary>
+        public YamlNode Node { get; }
+
+        /// <summary>
+        /// Gets the message.
+        /// </summary>
+        public string Message { get; }
+
+        public string FormattedMessage => $"{MessageType} {Node.Start.Line}:{Node.Start.Column}: {Message}";
+
+        public override string ToString()
+        {
+            return FormattedMessage;
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/DeserializationMessage.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/DeserializationMessage.cs
@@ -35,6 +35,9 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
         /// </summary>
         public string Message { get; }
 
+        /// <summary>
+        /// Gets the message formatted for output to users.
+        /// </summary>
         public string FormattedMessage => $"{MessageType} {Node.Start.Line}:{Node.Start.Column}: {Message}";
 
         public override string ToString()

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/Deserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/Deserializer.cs
@@ -13,6 +13,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
     public abstract class Deserializer<TObject> : IDeserializer<TObject>
         where TObject: new()
     {
+        private readonly HashSet<string> _ignoredFields = new HashSet<string>();
         private readonly Dictionary<string, FieldContext> _fields = new Dictionary<string, FieldContext>();
 
         protected ILogger Logger { get; }
@@ -31,6 +32,11 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
 
             foreach (var child in node.Children)
             {
+                if (_ignoredFields.Contains(child.Key.ToString()))
+                {
+                    continue;
+                }
+
                 if (_fields.TryGetValue(child.Key.ToString(), out var fieldContext))
                 {
                     fieldContext.SetValue(
@@ -111,6 +117,11 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
             var memberExpression = (MemberExpression)accessorExpression.Body;
             _fields[GetName(memberExpression)] = new FieldContext(
                 memberExpression.Member as PropertyInfo, false, default(TReturn), null, deserializer);
+        }
+
+        protected void IgnoreField(string fieldName)
+        {
+            _ignoredFields.Add(fieldName);
         }
 
         private static string GetName(MemberExpression memberExpression)

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/ErrorReporter.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/ErrorReporter.cs
@@ -1,15 +1,36 @@
+using System.Collections.Generic;
+using System.Linq;
+using GuardNet;
 using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization
 {
     public class ErrorReporter : IErrorReporter
     {
+        private readonly List<DeserializationMessage> _messages = new List<DeserializationMessage>();
+
+        /// <inheritdoc />
+        public IReadOnlyCollection<DeserializationMessage> Messages => _messages.OrderBy(m => m.Node.Start.Line).ToList();
+
+        /// <inheritdoc />
+        public bool HasErrors => Messages.Any(m => m.MessageType == MessageType.Error);
+
+        /// <inheritdoc />
         public void ReportError(YamlNode node, string message)
         {
+            Guard.NotNull(node, nameof(node));
+            Guard.NotNullOrEmpty(message, nameof(message));
+
+            _messages.Add(new DeserializationMessage(MessageType.Error, node, message));
         }
 
+        /// <inheritdoc />
         public void ReportWarning(YamlNode node, string message)
         {
+            Guard.NotNull(node, nameof(node));
+            Guard.NotNullOrEmpty(message, nameof(message));
+
+            _messages.Add(new DeserializationMessage(MessageType.Warning, node, message));
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/FieldDeserializationContext.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/FieldDeserializationContext.cs
@@ -1,0 +1,53 @@
+﻿using GuardNet;
+
+namespace Promitor.Core.Scraping.Configuration.Serialization
+{
+    /// <summary>
+    /// Used to store information about a field while it is being deserialized.
+    /// This object is not designed to be reused when deserializing multiple Yaml
+    /// nodes, and a new copy should be created each time an object is deserialized.
+    /// </summary>
+    public class FieldDeserializationContext<TObject>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FieldDeserializationContext{TObject}"/> type.
+        /// </summary>
+        /// <param name="deserializationInfo">The information about the field to deserialize.</param>
+        public FieldDeserializationContext(FieldDeserializationInfo deserializationInfo)
+        {
+            Guard.NotNull(deserializationInfo, nameof(deserializationInfo));
+
+            DeserializationInfo = deserializationInfo;
+        }
+
+        /// <summary>
+        /// Gets the information about the field to deserialize.
+        /// </summary>
+        public FieldDeserializationInfo DeserializationInfo { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the field has been set.
+        /// </summary>
+        public bool HasBeenSet { get; private set; }
+
+        /// <summary>
+        /// Sets the field on the specified target object.
+        /// </summary>
+        /// <param name="target">The object being deserialized.</param>
+        /// <param name="value">The value of the field.</param>
+        public void SetValue(TObject target, object value)
+        {
+            DeserializationInfo.PropertyInfo.SetValue(target, value);
+            HasBeenSet = true;
+        }
+
+        /// <summary>
+        /// Sets the field to its default value.
+        /// </summary>
+        /// <param name="target">The object being deserialized.</param>
+        public void SetDefaultValue(TObject target)
+        {
+            DeserializationInfo.PropertyInfo.SetValue(target, DeserializationInfo.DefaultValue);
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/FieldDeserializationInfo.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/FieldDeserializationInfo.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using YamlDotNet.RepresentationModel;
+
+namespace Promitor.Core.Scraping.Configuration.Serialization
+{
+    /// <summary>
+    /// Contains information and helper methods needed to deserialize a particular field.
+    /// This class should be immutable, and should be able to be reused when deserializing
+    /// multiple Yaml nodes.
+    /// </summary>
+    public class FieldDeserializationInfo
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FieldDeserializationInfo"/> type.
+        /// </summary>
+        /// <param name="propertyInfo">The property being deserialized.</param>
+        /// <param name="isRequired">Whether the field is required or not.</param>
+        /// <param name="defaultValue">The default value to use for the field if not specified.</param>
+        /// <param name="customMapperFunc">A custom function to use for getting the value of the field.</param>
+        /// <param name="deserializer">A deserializer to use to deserialize the field.</param>
+        public FieldDeserializationInfo(PropertyInfo propertyInfo, bool isRequired, object defaultValue, Func<string, KeyValuePair<YamlNode, YamlNode>, IErrorReporter, object> customMapperFunc, IDeserializer deserializer = null)
+        {
+            YamlFieldName = GetName(propertyInfo);
+            CustomMapperFunc = customMapperFunc;
+            PropertyInfo = propertyInfo;
+            IsRequired = isRequired;
+            DefaultValue = defaultValue;
+            Deserializer = deserializer;
+        }
+
+        /// <summary>
+        /// Gets the Yaml field name.
+        /// </summary>
+        public string YamlFieldName { get; }
+
+        /// <summary>
+        /// Gets information about the property that the field should be deserialized into.
+        /// </summary>
+        public PropertyInfo PropertyInfo { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the field is required or not.
+        /// </summary>
+        public bool IsRequired { get; }
+
+        /// <summary>
+        /// Gets the default value that should be used for the field if none is supplied.
+        /// </summary>
+        public object DefaultValue { get; }
+
+        /// <summary>
+        /// Gets a custom function that can be used to deserialize the field.
+        /// </summary>
+        public Func<string, KeyValuePair<YamlNode, YamlNode>, IErrorReporter, object> CustomMapperFunc { get; }
+
+        /// <summary>
+        /// Gets a deserializer to use when deserializing the field.
+        /// </summary>
+        public IDeserializer Deserializer { get; }
+
+        private static string GetName(MemberInfo propertyInfo)
+        {
+            return char.ToLowerInvariant(propertyInfo.Name[0]) + propertyInfo.Name.Substring(1);
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/IErrorReporter.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/IErrorReporter.cs
@@ -1,4 +1,5 @@
-﻿using YamlDotNet.RepresentationModel;
+﻿using System.Collections.Generic;
+using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization
 {
@@ -7,6 +8,16 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
     /// </summary>
     public interface IErrorReporter
     {
+        /// <summary>
+        /// Contains the list of messages reported, in order of line number.
+        /// </summary>
+        IReadOnlyCollection<DeserializationMessage> Messages { get; }
+
+        /// <summary>
+        /// Indicates if any errors were reported.
+        /// </summary>
+        bool HasErrors { get; }
+
         /// <summary>
         /// Reports an error.
         /// </summary>
@@ -18,7 +29,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
         /// Reports a warning (i.e. something that doesn't prevent Promitor from functioning).
         /// </summary>
         /// <param name="node">The node containing the error / that should be highlighted to the user.</param>
-        /// <param name="message">The error message.</param>
+        /// <param name="message">The warning message.</param>
         void ReportWarning(YamlNode node, string message);
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/MessageType.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/MessageType.cs
@@ -1,0 +1,18 @@
+namespace Promitor.Core.Scraping.Configuration.Serialization
+{
+    /// <summary>
+    /// Defines the type of message reported during deserialization.
+    /// </summary>
+    public enum MessageType
+    {
+        /// <summary>
+        /// The message is a warning, and doesn't prevent Promitor from functioning.
+        /// </summary>
+        Warning,
+
+        /// <summary>
+        /// The message is an error which means that Promitor cannot use the configuration.
+        /// </summary>
+        Error
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureMetricConfigurationDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureMetricConfigurationDeserializer.cs
@@ -9,7 +9,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
             : base(logger)
         {
             MapRequired(config => config.MetricName);
-            MapRequired(config => config.Dimension, dimensionDeserializer);
+            MapOptional(config => config.Dimension, dimensionDeserializer);
             MapRequired(config => config.Aggregation, aggregationDeserializer);
         }
     }

--- a/src/Promitor.Scraper.Host/Validation/Steps/MetricsDeclarationValidationStep.cs
+++ b/src/Promitor.Scraper.Host/Validation/Steps/MetricsDeclarationValidationStep.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -6,6 +7,7 @@ using Promitor.Core.Scraping.Configuration.Model;
 using Promitor.Core.Scraping.Configuration.Model.Metrics;
 using Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes;
 using Promitor.Core.Scraping.Configuration.Providers.Interfaces;
+using Promitor.Core.Scraping.Configuration.Serialization;
 using Promitor.Core.Serialization.Yaml;
 using Promitor.Scraper.Host.Validation.Interfaces;
 using Promitor.Scraper.Host.Validation.MetricDefinitions;
@@ -29,10 +31,18 @@ namespace Promitor.Scraper.Host.Validation.Steps
 
         public ValidationResult Run()
         {
-            var metricsDeclaration = _metricsDeclarationProvider.Get(applyDefaults: true);
+            var errorReporter = new ErrorReporter();
+            var metricsDeclaration = _metricsDeclarationProvider.Get(applyDefaults: true, errorReporter: errorReporter);
             if (metricsDeclaration == null)
             {
                 return ValidationResult.Failure(ComponentName, "Unable to deserialize configured metrics declaration");
+            }
+
+            LogDeserializationMessages(errorReporter);
+
+            if (errorReporter.HasErrors)
+            {
+                return ValidationResult.Failure(ComponentName, "Errors were found while deserializing the metric configuration.");
             }
 
             LogMetricsDeclaration(metricsDeclaration);
@@ -48,6 +58,21 @@ namespace Promitor.Scraper.Host.Validation.Steps
             validationErrors.AddRange(metricsErrorMessages);
 
             return validationErrors.Any() ? ValidationResult.Failure(ComponentName, validationErrors) : ValidationResult.Successful(ComponentName);
+        }
+
+        private void LogDeserializationMessages(IErrorReporter errorReporter)
+        {
+            foreach (var message in errorReporter.Messages)
+            {
+                if (message.MessageType == MessageType.Error)
+                {
+                    Logger.LogError(message.FormattedMessage);
+                }
+                else
+                {
+                    Logger.LogWarning(message.FormattedMessage);
+                }
+            }
         }
 
         private void LogMetricsDeclaration(MetricsDeclaration metricsDeclaration)

--- a/src/Promitor.Scraper.Host/Validation/Steps/MetricsDeclarationValidationStep.cs
+++ b/src/Promitor.Scraper.Host/Validation/Steps/MetricsDeclarationValidationStep.cs
@@ -62,15 +62,19 @@ namespace Promitor.Scraper.Host.Validation.Steps
 
         private void LogDeserializationMessages(IErrorReporter errorReporter)
         {
-            foreach (var message in errorReporter.Messages)
+            if (errorReporter.Messages.Any())
             {
-                if (message.MessageType == MessageType.Error)
+                var combinedMessages = string.Join(
+                    Environment.NewLine, errorReporter.Messages.Select(message => message.FormattedMessage));
+
+                var deserializationProblemsMessage = $"The following problems were found with the metric configuration:{Environment.NewLine}{combinedMessages}";
+                if (errorReporter.HasErrors)
                 {
-                    Logger.LogError(message.FormattedMessage);
+                    Logger.LogError(deserializationProblemsMessage);
                 }
                 else
                 {
-                    Logger.LogWarning(message.FormattedMessage);
+                    Logger.LogWarning(deserializationProblemsMessage);
                 }
             }
         }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/DeserializerTests/DeserializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/DeserializerTests/DeserializationTests.cs
@@ -236,8 +236,6 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.DeserializerTests
             Assert.Same(child, result.OptionalChild);
         }
 
-        // TODO: Test for duplicate field registration
-
         public class RegistrationConfig
         {
             public string Name { get; set; }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/DeserializerTests/ValidationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/DeserializerTests/ValidationTests.cs
@@ -133,6 +133,26 @@ country: Scotland");
                 r => r.ReportWarning(It.IsAny<YamlNode>(), It.Is<string>(s => s.Contains("customField"))), Times.Never);
         }
 
+        [Fact]
+        public void Deserialize_CalledMultipleTimes_DoesNotReusePreviousState()
+        {
+            // Since the deserializers are created once during startup, this test is to ensure
+            // that if the same deserializer is used to deserialize multiple Yaml nodes, we don't
+            // reuse the state from the previous time.
+
+            // Arrange
+            var node1 = YamlUtils.CreateYamlNode("name: Promitor");
+            var node2 = YamlUtils.CreateYamlNode("age: 20");
+
+            // Act
+            deserializer.Deserialize(node1, errorReporter.Object);
+            var result = deserializer.Deserialize(node2, errorReporter.Object);
+
+            // Assert
+            errorReporter.Verify(
+                r => r.ReportError(It.IsAny<YamlNode>(), It.Is<string>(s => s.Contains("name"))));
+        }
+
         // TODO: Check for invalid formats (crontab expression, timespan, etc)
         // TODO: Add a test to make sure that the error is against the mapping node rather than its value for missing required fields
 

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/DeserializerTests/ValidationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/DeserializerTests/ValidationTests.cs
@@ -119,6 +119,20 @@ country: Scotland");
             errorReporter.Verify(r => r.ReportError(dayValueNode, $"'twenty' is not a valid value for 'interval'. The value must be in the format 'hh:mm:ss'."));
         }
 
+        [Fact]
+        public void Deserialize_IgnoreField_DoesNotReportErrorIfFieldFound()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("customField: 1234");
+
+            // Act
+            deserializer.Deserialize(node, errorReporter.Object);
+
+            // Assert
+            errorReporter.Verify(
+                r => r.ReportWarning(It.IsAny<YamlNode>(), It.Is<string>(s => s.Contains("customField"))), Times.Never);
+        }
+
         // TODO: Check for invalid formats (crontab expression, timespan, etc)
         // TODO: Add a test to make sure that the error is against the mapping node rather than its value for missing required fields
 
@@ -138,6 +152,7 @@ country: Scotland");
                 MapOptional(t => t.Age);
                 MapOptional(t => t.Day);
                 MapOptional(t => t.Interval);
+                IgnoreField("customField");
             }
         }
     }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/ErrorReporterTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/ErrorReporterTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.ComponentModel;
+using Promitor.Core.Scraping.Configuration.Serialization;
+using Xunit;
+
+namespace Promitor.Scraper.Tests.Unit.Serialization
+{
+    [Category("Unit")]
+    public class ErrorReporterTests
+    {
+        private readonly ErrorReporter _errorReporter = new ErrorReporter();
+
+        [Fact]
+        public void ReportError_AfterErrorReported_AddsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("name: promitor");
+
+            // Act
+            _errorReporter.ReportError(node, "Test error message");
+
+            // Assert
+            Assert.Collection(_errorReporter.Messages,
+                m =>
+                {
+                    Assert.Equal(node, m.Node);
+                    Assert.Equal(MessageType.Error, m.MessageType);
+                    Assert.Equal("Test error message", m.Message);
+                });
+        }
+
+        [Fact]
+        public void ReportError_NullNode_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>(() => _errorReporter.ReportError(null, "Test error"));
+        }
+
+        [Fact]
+        public void ReportError_NullMessage_ThrowsException()
+        {
+            Assert.Throws<ArgumentException>(
+                () => _errorReporter.ReportError(YamlUtils.CreateYamlNode("name: promitor"), null));
+        }
+
+        [Fact]
+        public void ReportError_EmptyMessage_ThrowsException()
+        {
+            Assert.Throws<ArgumentException>(
+                () => _errorReporter.ReportError(YamlUtils.CreateYamlNode("name: promitor"), string.Empty));
+        }
+
+        [Fact]
+        public void ReportWarning_NullNode_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>(() => _errorReporter.ReportWarning(null, "Test warning"));
+        }
+
+        [Fact]
+        public void ReportWarning_NullMessage_ThrowsException()
+        {
+            Assert.Throws<ArgumentException>(
+                () => _errorReporter.ReportWarning(YamlUtils.CreateYamlNode("name: promitor"), null));
+        }
+
+        [Fact]
+        public void ReportWarning_EmptyMessage_ThrowsException()
+        {
+            Assert.Throws<ArgumentException>(
+                () => _errorReporter.ReportWarning(YamlUtils.CreateYamlNode("name: promitor"), string.Empty));
+        }
+
+        [Fact]
+        public void ReportWarning_AfterWarningReported_AddsWarning()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("name: promitor");
+
+            // Act
+            _errorReporter.ReportWarning(node, "Test warning message");
+
+            // Assert
+            Assert.Collection(_errorReporter.Messages,
+                m =>
+                {
+                    Assert.Equal(node, m.Node);
+                    Assert.Equal(MessageType.Warning, m.MessageType);
+                    Assert.Equal("Test warning message", m.Message);
+                });
+        }
+
+        [Fact]
+        public void HasErrors_AfterErrorReported_True()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("name: promitor");
+            _errorReporter.ReportError(node, "Test error message");
+
+            // Act
+            var hasErrors = _errorReporter.HasErrors;
+
+            // Assert
+            Assert.True(hasErrors);
+        }
+
+        [Fact]
+        public void HasErrors_AfterWarningReported_False()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("name: promitor");
+            _errorReporter.ReportWarning(node, "Test warning");
+
+            // Act
+            var hasErrors = _errorReporter.HasErrors;
+
+            // Assert
+            Assert.False(hasErrors);
+        }
+
+        [Fact]
+        public void Messages_MultipleMessagesAdded_ReturnedInOrderOfLineNumber()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode(
+@"firstNode: one
+secondNode: two
+thirdNode: three");
+
+            _errorReporter.ReportWarning(node.Children["secondNode"], "second");
+            _errorReporter.ReportError(node.Children["firstNode"], "first");
+            _errorReporter.ReportWarning(node.Children["thirdNode"], "third");
+
+            // Act
+            var messages = _errorReporter.Messages;
+
+            // Assert
+            Assert.Collection(messages,
+                m => Assert.Equal("first", m.Message),
+                m => Assert.Equal("second", m.Message),
+                m => Assert.Equal("third", m.Message));
+        }
+    }
+}

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/V1SerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/V1SerializationTests.cs
@@ -180,7 +180,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.v1
             var yaml = _configurationSerializer.Serialize(_metricsDeclaration);
 
             // Act
-            var runtimeModel = _configurationSerializer.Deserialize(yaml);
+            var runtimeModel = _configurationSerializer.Deserialize(yaml, _errorReporter);
 
             // Assert
             Assert.NotNull(runtimeModel);

--- a/src/Promitor.Scraper.Tests.Unit/Validation/Metrics/ResourceTypes/ServiceBusQueueMetricsDeclarationValidationStepTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Validation/Metrics/ResourceTypes/ServiceBusQueueMetricsDeclarationValidationStepTests.cs
@@ -74,7 +74,7 @@ namespace Promitor.Scraper.Tests.Unit.Validation.Metrics.ResourceTypes
             var validationResult = scrapingScheduleValidationStep.Run();
 
             // Assert
-            Assert.True(validationResult.IsSuccessful, "Validation was successful");
+            Assert.False(validationResult.IsSuccessful, "Validation was successful but should have failed");
         }
 
         [Fact]


### PR DESCRIPTION
This PR hooks up the validation improvements to the Promitor validation code so that if problems are found during deserialization, they are reported to the console and Promitor stops executing (if any of the problems are errors).

Here's an example test config file:

```yaml
version: v1
azureMetadata:
  tnantId: abcd-1234
  subscriptionId: abcd-1234
  resourceGroupName: promitor
metricDefaults:
  aggregation:
    interval: 00:05:00
  scraping:
    # Every minute
    schedule: "0 * * ? * *"
metrics:
  - name: promitor_demo_generic_queue_size
    description: "Amount of active messages of the 'orders' queue (determined with Generic provider)"
    resourceType: Generic
    labels:
      app: promitor
    azureMetricConfiguration:
      metricName: ActiveMessages
      aggregation:
        type: Average
    #resources:
    #- resourceUri: Microsoft.ServiceBus/namespaces/promitor-messaging
    #  filter: EntityName eq 'orders'
  - name: promitor_demo_generic_namespace_size
    description: "Size of all queues in our Azure Service Bus namespace (determined with Generic provider)"
    resourceType: Generic
    scraping:
      # Every 2 minutes
      schedule: "0 */2 * ? * *"
    azureMetricConfiguration:
      metricName: ActiveMessages
      aggregation:
        type: Average
    resources:
    - resourceUri: Microsoft.ServiceBus/namespaces/promitor-messaging
      # filter is deliberately omitted given filter is optional
  - name: promitor_demo_servicebusqueue_queue_size
    description: "Amount of active messages of the 'orders' queue (determined with ServiceBusQueue provider)"
    resourceType: ServiceBusQueue
    azureMetricConfiguration:
      metricName: ActiveMessages
      aggregation:
        type: Average
        # Optionally override the default aggregation interval (metricDefaults.aggregation.interval)
        interval: 00:15:00
    resources:
    - namespace: promitor-messaging
      queueName: orders
  - name: promitor_demo_azurestoragequeue_queue_size
    description: "Approximate amount of messages in 'orders' queue (determined with StorageQueue provider)"
    resourceType: StorageQueue
    scraping:
      # Every 2 minutes
      schedule: "0 */2 * ? * *"
    azureMetricConfiguration:
      metricName: MessageCount
      aggregation:
        type: Total
    resources:
    - accountName: promitor-acct
      queueName: orders
      sasToken:
        rawValue: "?sv=2018-03-28&ss=bfqt&srt=sco&sp=rwla&se=2022-08-07T00:16:01Z&st=2019-08-06T16:16:01Z&spr=https&sig=Ik4jprS89kGIFRM0qaQpXrv0ttP3pnlhmGQuYVQ7cbA%3D"
  - #name: promitor_demo_azurestoragequeue_queue_timespentinqueue
    #description: "Approximate amount of time that the oldest message has been in 'orders' queue (determined with StorageQueue provider)"
    resourceType: StorageQueue
    azureMetricConfiguration:
      metricName: TimeSpentInQueue
      aggregation:
        type: Total
    resources:
    - accountName: promitor
      queueName: orders
      sasToken:
        rawValue: superSecret!!!
        environmentVariable: SECRETS_STORAGEQUEUE_SAS
```

Here's the output when running Promitor:

```shell
██████╗ ██████╗  ██████╗ ███╗   ███╗██╗████████╗ ██████╗ ██████╗
██╔══██╗██╔══██╗██╔═══██╗████╗ ████║██║╚══██╔══╝██╔═══██╗██╔══██╗
██████╔╝██████╔╝██║   ██║██╔████╔██║██║   ██║   ██║   ██║██████╔╝
██╔═══╝ ██╔══██╗██║   ██║██║╚██╔╝██║██║   ██║   ██║   ██║██╔══██╗
██║     ██║  ██║╚██████╔╝██║ ╚═╝ ██║██║   ██║   ╚██████╔╝██║  ██║
╚═╝     ╚═╝  ╚═╝ ╚═════╝ ╚═╝     ╚═╝╚═╝   ╚═╝    ╚═════╝ ╚═╝  ╚═╝
[16:11:46 ERR] The following problems were found with the metric configuration:
Warning 3:3: Unknown field 'tnantId'.
Error 3:3: 'tenantId' is a required field but was not found.
Error 13:5: 'resources' is a required field but was not found.
Error 67:5: 'name' is a required field but was not found.
Error 67:5: 'description' is a required field but was not found.
Warning 76:9: Secret with environment variable 'SECRETS_STORAGEQUEUE_SAS' also has a rawValue provided.
[16:11:46 WRN] Validation step 3/3 failed. Error(s): Errors were found while deserializing the metric configuration.
[16:11:46 FTL] Promitor is not configured correctly. Please fix validation issues and re-run.
[16:11:46 FTL] Application startup exception
Promitor.Scraper.Host.Validation.Exceptions.ValidationFailedException: Validation Failed. Errors:- Metrics Declaration: Errors were found while deserializing the metric configuration.

   at Promitor.Scraper.Host.Validation.RuntimeValidator.ProcessValidationResults(List`1 validationResults) in C:\Users\AdamConnelly\github.com\adamrpconnelly\promitor\src\Promitor.Scraper.Host\Validation\RuntimeValidator.cs:line 56
   at Promitor.Scraper.Host.Validation.RuntimeValidator.Run() in C:\Users\AdamConnelly\github.com\adamrpconnelly\promitor\src\Promitor.Scraper.Host\Validation\RuntimeValidator.cs:line 42
   at Promitor.Scraper.Host.Startup.ValidateRuntimeConfiguration(IApplicationBuilder app) in C:\Users\AdamConnelly\github.com\adamrpconnelly\promitor\src\Promitor.Scraper.Host\Startup.cs:line 60
   at Promitor.Scraper.Host.Startup.Configure(IApplicationBuilder app, IWebHostEnvironment env) in C:\Users\AdamConnelly\github.com\adamrpconnelly\promitor\src\Promitor.Scraper.Host\Startup.cs:line 36
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at Microsoft.AspNetCore.Hosting.ConfigureBuilder.Invoke(Object instance, IApplicationBuilder builder)
   at Microsoft.AspNetCore.Hosting.ConfigureBuilder.<>c__DisplayClass4_0.<Build>b__0(IApplicationBuilder builder)
   at Microsoft.AspNetCore.Hosting.GenericWebHostBuilder.<>c__DisplayClass13_0.<UseStartup>b__2(IApplicationBuilder app)
   at Microsoft.AspNetCore.Mvc.Filters.MiddlewareFilterBuilderStartupFilter.<>c__DisplayClass0_0.<Configure>g__MiddlewareFilterBuilder|0(IApplicationBuilder builder)
   at Microsoft.AspNetCore.HostFilteringStartupFilter.<>c__DisplayClass0_0.<Configure>b__0(IApplicationBuilder app)
   at Microsoft.AspNetCore.Hosting.GenericWebHostService.StartAsync(CancellationToken cancellationToken)
Unhandled exception. Promitor.Scraper.Host.Validation.Exceptions.ValidationFailedException: Validation Failed. Errors:- Metrics Declaration: Errors were found while deserializing the metric configuration.

   at Promitor.Scraper.Host.Validation.RuntimeValidator.ProcessValidationResults(List`1 validationResults) in C:\Users\AdamConnelly\github.com\adamrpconnelly\promitor\src\Promitor.Scraper.Host\Validation\RuntimeValidator.cs:line 56
   at Promitor.Scraper.Host.Validation.RuntimeValidator.Run() in C:\Users\AdamConnelly\github.com\adamrpconnelly\promitor\src\Promitor.Scraper.Host\Validation\RuntimeValidator.cs:line 42
   at Promitor.Scraper.Host.Startup.ValidateRuntimeConfiguration(IApplicationBuilder app) in C:\Users\AdamConnelly\github.com\adamrpconnelly\promitor\src\Promitor.Scraper.Host\Startup.cs:line 60
   at Promitor.Scraper.Host.Startup.Configure(IApplicationBuilder app, IWebHostEnvironment env) in C:\Users\AdamConnelly\github.com\adamrpconnelly\promitor\src\Promitor.Scraper.Host\Startup.cs:line 36
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at Microsoft.AspNetCore.Hosting.ConfigureBuilder.Invoke(Object instance, IApplicationBuilder builder)
   at Microsoft.AspNetCore.Hosting.ConfigureBuilder.<>c__DisplayClass4_0.<Build>b__0(IApplicationBuilder builder)
   at Microsoft.AspNetCore.Hosting.GenericWebHostBuilder.<>c__DisplayClass13_0.<UseStartup>b__2(IApplicationBuilder app)
   at Microsoft.AspNetCore.Mvc.Filters.MiddlewareFilterBuilderStartupFilter.<>c__DisplayClass0_0.<Configure>g__MiddlewareFilterBuilder|0(IApplicationBuilder builder)
   at Microsoft.AspNetCore.HostFilteringStartupFilter.<>c__DisplayClass0_0.<Configure>b__0(IApplicationBuilder app)
   at Microsoft.AspNetCore.Hosting.GenericWebHostService.StartAsync(CancellationToken cancellationToken)
   at Microsoft.Extensions.Hosting.Internal.Host.StartAsync(CancellationToken cancellationToken)
   at Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.RunAsync(IHost host, CancellationToken token)
   at Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.RunAsync(IHost host, CancellationToken token)
   at Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.Run(IHost host)
   at Promitor.Scraper.Host.Program.Main(String[] args) in C:\Users\AdamConnelly\github.com\adamrpconnelly\promitor\src\Promitor.Scraper.Host\Program.cs:line 23
```

Here's the output if we fix the errors, leaving only warnings:

```shell
[16:17:10 WRN] The following problems were found with the metric configuration:
Warning 6:3: Unknown field 'unknownProp'.
Warning 77:9: Secret with environment variable 'SECRETS_STORAGEQUEUE_SAS' also has a rawValue provided.
```